### PR TITLE
Implement par_compute_global_potential

### DIFF
--- a/tests/unit_tests/assembly/global.rs
+++ b/tests/unit_tests/assembly/global.rs
@@ -263,35 +263,38 @@ impl ElementConnectivityAssembler for MockElementAssembler {
     }
 }
 
-#[test]
-fn test_compute_global_potential() {
-    struct MockScalarElementAssembler;
+struct MockScalarElementAssembler;
 
-    #[rustfmt::skip]
-    impl ElementConnectivityAssembler for MockScalarElementAssembler {
-        fn solution_dim(&self) -> usize { unreachable!() }
-        fn num_elements(&self) -> usize { 4 }
-        fn num_nodes(&self) -> usize { unreachable!() }
-        fn element_node_count(&self, _element_index: usize) -> usize { unreachable!() }
-        fn populate_element_nodes(&self, _output: &mut [usize], _element_index: usize) { unreachable!() }
-    }
+#[rustfmt::skip]
+impl ElementConnectivityAssembler for MockScalarElementAssembler {
+    fn solution_dim(&self) -> usize { unreachable!() }
+    fn num_elements(&self) -> usize { 4 }
+    fn num_nodes(&self) -> usize { unreachable!() }
+    fn element_node_count(&self, _element_index: usize) -> usize { unreachable!() }
+    fn populate_element_nodes(&self, _output: &mut [usize], _element_index: usize) { unreachable!() }
+}
 
-    #[rustfmt::skip]
-    impl ElementScalarAssembler<f64> for MockScalarElementAssembler {
-        fn assemble_element_scalar(&self, element_index: usize) -> eyre::Result<f64> {
-            match element_index {
-                0 => Ok(3.0),
-                1 => Ok(4.0),
-                2 => Ok(5.0),
-                3 => Ok(-3.0),
-                _ => Err(eyre!("Element out of bounds"))
-            }
+#[rustfmt::skip]
+impl ElementScalarAssembler<f64> for MockScalarElementAssembler {
+    fn assemble_element_scalar(&self, element_index: usize) -> eyre::Result<f64> {
+        match element_index {
+            0 => Ok(3.0),
+            1 => Ok(4.0),
+            2 => Ok(5.0),
+            3 => Ok(-3.0),
+            _ => Err(eyre!("Element out of bounds"))
         }
     }
+}
 
+#[test]
+fn test_compute_global_potential() {
     let global_potential = compute_global_potential(&MockScalarElementAssembler).unwrap();
     assert_scalar_eq!(global_potential, 9.0, comp = float);
+}
 
+#[test]
+fn test_par_compute_global_potential() {
     let par_global_potential = par_compute_global_potential(&MockScalarElementAssembler).unwrap();
     assert_scalar_eq!(par_global_potential, 9.0, comp = float);
 }

--- a/tests/unit_tests/assembly/global.rs
+++ b/tests/unit_tests/assembly/global.rs
@@ -7,7 +7,7 @@ use proptest::prelude::*;
 use eyre::eyre;
 use fenris::assembly::global::{
     apply_homogeneous_dirichlet_bc_csr, apply_homogeneous_dirichlet_bc_matrix, compute_global_potential,
-    gather_global_to_local, CsrAssembler, CsrParAssembler,
+    gather_global_to_local, par_compute_global_potential, CsrAssembler, CsrParAssembler,
 };
 use fenris::assembly::local::{ElementConnectivityAssembler, ElementScalarAssembler};
 use fenris::nalgebra::{DMatrix, DVector, U2};
@@ -290,8 +290,10 @@ fn test_compute_global_potential() {
     }
 
     let global_potential = compute_global_potential(&MockScalarElementAssembler).unwrap();
-
     assert_scalar_eq!(global_potential, 9.0, comp = float);
+
+    let par_global_potential = par_compute_global_potential(&MockScalarElementAssembler).unwrap();
+    assert_scalar_eq!(par_global_potential, 9.0, comp = float);
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
This implements a parallel version of `compute_global_potential` using Rayon with `map` + `try_reduce`.