### PR TITLE
Implement VectorParAssembler

### DIFF
--- a/examples/poisson2d.rs
+++ b/examples/poisson2d.rs
@@ -2,7 +2,7 @@ use eyre::eyre;
 use nalgebra::Vector1;
 
 use fenris::assembly::global::{
-    apply_homogeneous_dirichlet_bc_csr, apply_homogeneous_dirichlet_bc_rhs, CsrAssembler, SerialVectorAssembler,
+    apply_homogeneous_dirichlet_bc_csr, apply_homogeneous_dirichlet_bc_rhs, CsrAssembler, VectorAssembler,
 };
 use fenris::assembly::local::{
     ElementEllipticAssemblerBuilder, ElementSourceAssemblerBuilder, SourceFunction, UniformQuadratureTable,
@@ -43,7 +43,7 @@ fn assemble_linear_system(mesh: &QuadMesh2d<f64>) -> eyre::Result<(CsrMatrix<f64
 
     // Set up global assemblers. These are responsible for adding element matrix/vector entries from
     // each element into the global matrix/vector
-    let vector_assembler = SerialVectorAssembler::<f64>::default();
+    let vector_assembler = VectorAssembler::<f64>::default();
     let matrix_assembler = CsrAssembler::default();
 
     // Set up local matrix assembler for the Laplace operator. This assembler is responsible

--- a/fenris-geometry/src/lib.rs
+++ b/fenris-geometry/src/lib.rs
@@ -193,9 +193,9 @@ where
     }
 
     pub fn intersects(&self, other: &Self) -> bool {
-        for i in 0 .. D::dim() {
+        for i in 0..D::dim() {
             if !intervals_intersect([self.min[i], self.max[i]], [other.min[i], other.max[i]]) {
-                return false
+                return false;
             }
         }
         true

--- a/fenris-geometry/tests/unit_tests/aabb.rs
+++ b/fenris-geometry/tests/unit_tests/aabb.rs
@@ -12,7 +12,7 @@ fn aabb_intersects_2d() {
             assert!(!aabb1.intersects(&$aabb2));
             // Check that we get the same result when reversing the order
             assert!(!$aabb2.intersects(&aabb1));
-        }
+        };
     }
 
     macro_rules! assert_intersection {
@@ -20,7 +20,7 @@ fn aabb_intersects_2d() {
             assert!(aabb1.intersects(&$aabb2));
             // Check that we get the same result when reversing the order
             assert!($aabb2.intersects(&aabb1));
-        }
+        };
     }
 
     assert_no_intersection!(Aabb::new(vector![6.0, 4.0], vector![9.0, 6.0]));

--- a/fenris-solid/tests/unit_tests/gravity_source.rs
+++ b/fenris-solid/tests/unit_tests/gravity_source.rs
@@ -1,4 +1,4 @@
-use fenris::assembly::global::{CsrAssembler, SerialVectorAssembler};
+use fenris::assembly::global::{CsrAssembler, VectorAssembler};
 use fenris::assembly::local::{Density, ElementMassAssembler, ElementSourceAssemblerBuilder, UniformQuadratureTable};
 use fenris::mesh::procedural::create_unit_square_uniform_quad_mesh_2d;
 use fenris::mesh::QuadMesh2d;
@@ -29,7 +29,7 @@ fn gravity_source_agrees_with_mass_matrix_vector_product_quad4() {
         .with_quadrature_table(&mass_quadrature)
         .with_finite_element_space(&mesh)
         .build();
-    let f_gravity = SerialVectorAssembler::default()
+    let f_gravity = VectorAssembler::default()
         .assemble_vector(&gravity_assembler)
         .unwrap();
 

--- a/src/assembly/global.rs
+++ b/src/assembly/global.rs
@@ -292,7 +292,6 @@ impl<T: RealField + Send> CsrParAssembler<T> {
         colors: &[DisjointSubsets],
         element_assembler: &(dyn Sync + ElementMatrixAssembler<T>),
     ) -> eyre::Result<()> {
-        // -> Result<(), Box<dyn Error + Send + Sync>> {
         let sdim = element_assembler.solution_dim();
 
         for color in colors {

--- a/src/assembly/global.rs
+++ b/src/assembly/global.rs
@@ -514,12 +514,12 @@ pub fn color_nodes<C: FiniteElementConnectivity + ?Sized>(connectivity: &C) -> V
 }
 
 #[derive(Debug)]
-struct SerialVectorAssemblerWorkspace<T: Scalar> {
+struct VectorAssemblerWorkspace<T: Scalar> {
     vector: DVector<T>,
     nodes: Vec<usize>,
 }
 
-impl<T: RealField> Default for SerialVectorAssemblerWorkspace<T> {
+impl<T: RealField> Default for VectorAssemblerWorkspace<T> {
     fn default() -> Self {
         Self {
             vector: DVector::zeros(0),
@@ -529,19 +529,19 @@ impl<T: RealField> Default for SerialVectorAssemblerWorkspace<T> {
 }
 
 #[derive(Debug)]
-pub struct SerialVectorAssembler<T: Scalar> {
-    workspace: RefCell<SerialVectorAssemblerWorkspace<T>>,
+pub struct VectorAssembler<T: Scalar> {
+    workspace: RefCell<VectorAssemblerWorkspace<T>>,
 }
 
-impl<T: RealField> Default for SerialVectorAssembler<T> {
+impl<T: RealField> Default for VectorAssembler<T> {
     fn default() -> Self {
         Self {
-            workspace: RefCell::new(SerialVectorAssemblerWorkspace::default()),
+            workspace: RefCell::new(VectorAssemblerWorkspace::default()),
         }
     }
 }
 
-impl<T: RealField> SerialVectorAssembler<T> {
+impl<T: RealField> VectorAssembler<T> {
     pub fn assemble_vector_into<'a>(
         &self,
         output: impl Into<DVectorSliceMut<'a, T>>,
@@ -580,7 +580,7 @@ impl<T: RealField> SerialVectorAssembler<T> {
 
 #[derive(Debug)]
 pub struct VectorParAssembler<T: Scalar + Send> {
-    workspace: ThreadLocal<RefCell<SerialVectorAssemblerWorkspace<T>>>,
+    workspace: ThreadLocal<RefCell<VectorAssemblerWorkspace<T>>>,
 }
 
 impl<T: RealField> Default for VectorParAssembler<T> {

--- a/tests/convergence_tests/poisson_2d_mms.rs
+++ b/tests/convergence_tests/poisson_2d_mms.rs
@@ -63,7 +63,7 @@ pub fn solve_and_produce_output<C>(
     quadrature: QuadraturePair2d<f64>,
     error_quadrature: QuadraturePair2d<f64>,
 ) where
-    C: VtkCellConnectivity + ElementConnectivity<f64, GeometryDim = U2, ReferenceDim = U2>,
+    C: VtkCellConnectivity + ElementConnectivity<f64, GeometryDim = U2, ReferenceDim = U2> + Sync,
 {
     crate::convergence_tests::poisson_mms_common::solve_and_produce_output(
         element_name,

--- a/tests/convergence_tests/poisson_3d_mms.rs
+++ b/tests/convergence_tests/poisson_3d_mms.rs
@@ -64,7 +64,7 @@ pub fn solve_and_produce_output<C>(
     quadrature: QuadraturePair3d<f64>,
     error_quadrature: QuadraturePair3d<f64>,
 ) where
-    C: VtkCellConnectivity + ElementConnectivity<f64, GeometryDim = U3, ReferenceDim = U3>,
+    C: VtkCellConnectivity + ElementConnectivity<f64, GeometryDim = U3, ReferenceDim = U3> + Sync,
 {
     crate::convergence_tests::poisson_mms_common::solve_and_produce_output(
         element_name,

--- a/tests/convergence_tests/poisson_mms_common.rs
+++ b/tests/convergence_tests/poisson_mms_common.rs
@@ -1,6 +1,9 @@
 use eyre::eyre;
 use fenris::allocators::{SmallDimAllocator, TriDimAllocator};
-use fenris::assembly::global::{CsrAssembler, CsrParAssembler, SerialVectorAssembler, VectorParAssembler, apply_homogeneous_dirichlet_bc_csr, apply_homogeneous_dirichlet_bc_rhs, color_nodes};
+use fenris::assembly::global::{
+    apply_homogeneous_dirichlet_bc_csr, apply_homogeneous_dirichlet_bc_rhs, color_nodes, CsrAssembler, CsrParAssembler,
+    VectorAssembler, VectorParAssembler,
+};
 use fenris::assembly::local::{
     ElementEllipticAssemblerBuilder, ElementSourceAssemblerBuilder, SourceFunction, UniformQuadratureTable,
 };
@@ -84,7 +87,7 @@ where
     // Node coloring for test of parallel assembler
     let colors = color_nodes(mesh);
 
-    let vector_assembler = SerialVectorAssembler::<f64>::default();
+    let vector_assembler = VectorAssembler::<f64>::default();
     let matrix_assembler = CsrAssembler::default();
 
     let source_assembler = ElementSourceAssemblerBuilder::new()
@@ -119,7 +122,9 @@ where
         let pattern = par_matrix_assembler.assemble_pattern(&laplace_assembler);
         let nnz = pattern.nnz();
         let mut par_a_global = CsrMatrix::try_from_pattern_and_values(pattern, vec![0.0; nnz]).unwrap();
-        par_matrix_assembler.assemble_into_csr(&mut par_a_global, &colors, &laplace_assembler).unwrap();
+        par_matrix_assembler
+            .assemble_into_csr(&mut par_a_global, &colors, &laplace_assembler)
+            .unwrap();
         assert_matrix_eq!(a_global, par_a_global, comp = float);
     }
 

--- a/tests/unit_tests/assembly/local.rs
+++ b/tests/unit_tests/assembly/local.rs
@@ -1,5 +1,5 @@
 use fenris::allocators::{BiDimAllocator, SmallDimAllocator};
-use fenris::assembly::global::{compute_global_potential, CsrAssembler, SerialVectorAssembler};
+use fenris::assembly::global::{compute_global_potential, CsrAssembler, VectorAssembler};
 use fenris::assembly::local::{
     assemble_element_mass_matrix, AggregateElementAssembler, ElementConnectivityAssembler,
     ElementEllipticAssemblerBuilder, UniformQuadratureTable,
@@ -205,11 +205,11 @@ fn aggregate_element_assembler_repeated_assembler() {
     assert_scalar_eq!(aggregate_scalar, expected_scalar, comp = float);
 
     // Vector
-    let aggregate_vector = SerialVectorAssembler::default()
+    let aggregate_vector = VectorAssembler::default()
         .assemble_vector(&aggregate)
         .unwrap();
     let expected_vector = 2.0
-        * SerialVectorAssembler::default()
+        * VectorAssembler::default()
             .assemble_vector(&assembler)
             .unwrap();
     assert_matrix_eq!(aggregate_vector, expected_vector, comp = float);
@@ -261,7 +261,7 @@ fn aggregate_element_assembler_multibody() {
     assert_scalar_eq!(aggregate_scalar, expected_scalar, comp = float);
 
     // Vector
-    let vector_assembler = SerialVectorAssembler::default();
+    let vector_assembler = VectorAssembler::default();
     let aggregate_vector = vector_assembler.assemble_vector(&aggregate).unwrap();
     let expected_vector1 = vector_assembler.assemble_vector(&assembler1).unwrap();
     let expected_vector2 = vector_assembler.assemble_vector(&assembler2).unwrap();


### PR DESCRIPTION
This PR mainly
- refactors `color_nodes` to use `&FiniteElementConnectivity + ?Sized` instead of `&[Connectivity]`
- renames `SerialVectorAssembler` to `VectorAssembler`
- implements `VectorParAssembler`
- adds `assert_eq` checks to the convergence tests to compare the results of the serial and parallel assemblers

The interface of the `VectorParAssembler` is currently only
```rust
impl<T: RealField> VectorParAssembler<T> {
    pub fn assemble_vector_into<'a>(
        &self,
        output: impl Into<DVectorSliceMut<'a, T>>,
        colors: &[DisjointSubsets],
        element_assembler: &(impl ElementVectorAssembler<T> + ?Sized + Sync),
    ) -> eyre::Result<()>;
}
```