### PR TITLE
Add github actions workflow, fix doc errors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,14 +90,14 @@ jobs:
         with:
           toolchain: stable
           override: true
-      - name: Build tests
-        run: cargo build --tests --workspace
-      - name: Build tests (release)
-        run: cargo build --tests --workspace --release
+      - name: Build all tests (cargo build --tests --workspace --all-targets)
+        run: cargo build --tests --workspace --all-targets
+      - name: Build tests, release (cargo build --tests --workspace --all-targets --release)
+        run: cargo build --tests --workspace --all-targets --release
       - name: Run tests without convergence tests
-        run: cargo test --workspace -- --skip convergence
-      - name: Run tests without convergence tests (release)
-        run: cargo test --workspace --release -- --skip convergence
+        run: cargo test --workspace --all-targets -- --skip convergence_tests::
+      - name: Run tests without convergence tests, release
+        run: cargo test --workspace --all-targets --release -- --skip convergence_tests::
 
   cargo-test-convergence:
     
@@ -118,9 +118,9 @@ jobs:
         with:
           toolchain: stable
           override: true
-      - name: Build tests
-        run: cargo build --tests --workspace
-      - name: Build tests (release)
-        run: cargo build --tests --workspace --release
-      - name: Run convergence tests (release)
+      - name: Build all tests (cargo build --tests --workspace --all-targets)
+        run: cargo build --tests --workspace --all-targets
+      - name: Build tests, release (cargo build --tests --workspace --all-targets --release)
+        run: cargo build --tests --workspace --all-targets --release
+      - name: Run convergence tests, release
         run: cargo test --workspace --release --test convergence

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,126 @@
+name: Build and test
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  cargo-fmt-check:
+    
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Check format
+        run: cargo fmt -- --check
+
+  cargo-check:
+    
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-check-${{ hashFiles('**/Cargo.toml') }}
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Check
+        run: cargo check --verbose
+      - name: Check tests
+        run: cargo check --tests --verbose
+      - name: Check examples
+        run: cargo check --examples --verbose
+
+  cargo-doc:
+    
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-check-${{ hashFiles('**/Cargo.toml') }}
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Build and check doc
+        run: RUSTDOCFLAGS='-D warnings --html-in-header assets/doc-header.html' cargo doc --all-features --no-deps
+
+  cargo-test-basic:
+    
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.toml') }}
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Build tests
+        run: cargo build --tests --workspace
+      - name: Build tests (release)
+        run: cargo build --tests --workspace --release
+      - name: Run tests without convergence tests
+        run: cargo test --workspace -- --skip convergence
+      - name: Run tests without convergence tests (release)
+        run: cargo test --workspace --release -- --skip convergence
+
+  cargo-test-convergence:
+    
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.toml') }}
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Build tests
+        run: cargo build --tests --workspace
+      - name: Build tests (release)
+        run: cargo build --tests --workspace --release
+      - name: Run convergence tests (release)
+        run: cargo test --workspace --release --test convergence

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,9 +95,9 @@ jobs:
       - name: Build tests, release (cargo build --tests --workspace --all-targets --release)
         run: cargo build --tests --workspace --all-targets --release
       - name: Run tests without convergence tests
-        run: cargo test --workspace --all-targets -- --skip convergence_tests::
+        run: cargo test --workspace --all-targets -- --skip "convergence_tests::"
       - name: Run tests without convergence tests, release
-        run: cargo test --workspace --all-targets --release -- --skip convergence_tests::
+        run: cargo test --workspace --all-targets --release -- --skip "convergence_tests::"
 
   cargo-test-convergence:
     

--- a/fenris-paradis/src/adapter.rs
+++ b/fenris-paradis/src/adapter.rs
@@ -14,8 +14,8 @@ use std::marker::PhantomData;
 /// For illustration, see the below example.
 ///
 /// ```rust
-/// use paradis::DisjointSubsets;
-/// use paradis::adapter::BlockAdapter;
+/// use fenris_paradis::DisjointSubsets;
+/// use fenris_paradis::adapter::BlockAdapter;
 /// use rayon::iter::ParallelIterator;
 ///
 /// // 7 blocks of 3

--- a/fenris-paradis/src/lib.rs
+++ b/fenris-paradis/src/lib.rs
@@ -113,7 +113,7 @@ pub unsafe trait ParallelIndexedAccess<'record>: Sync + Send + Clone {
 /// we never access the same element from two threads.
 ///
 /// ```rust
-/// use paradis::{ParallelIndexedCollection, ParallelIndexedAccess};
+/// use fenris_paradis::{ParallelIndexedCollection, ParallelIndexedAccess};
 /// use crossbeam::scope;
 ///
 /// fn par_double_all_numbers(numbers: &mut [i32]) {

--- a/src/assembly/operators.rs
+++ b/src/assembly/operators.rs
@@ -183,7 +183,7 @@ where
 /// that represents some energy-like quantity *per unit volume*. Typically the elliptic energy
 /// arises in applications as the total potential energy over the domain
 ///
-/// $$ E\[u\] := \int_{\Omega} \psi (\nabla u) \dx. $$
+/// <div>$$ E[u] := \int_{\Omega} \psi (\nabla u) \dx. $$</div>
 ///
 /// The elliptic energy is then related to the elliptic operator
 /// $g: \mathbb{R}^{d \times s} \rightarrow \mathbb{R}^{d \times s}$ by the relation
@@ -200,7 +200,7 @@ where
 ///
 /// The simplest example of an elliptic energy is the
 /// [Dirichlet energy](https://en.wikipedia.org/wiki/Dirichlet_energy)
-/// $$ E\[u\] = \int_{\Omega} \frac{1}{2} \| \nabla u \|^2 \dx $$
+/// <div>$$ E[u] = \int_{\Omega} \frac{1}{2} \| \nabla u \|^2 \dx $$</div>
 /// where in our framework, $ \psi (\nabla u) = \frac{1}{2} \| \nabla u \|^2$ and
 /// $g = \nabla u$, which gives the weak form associated with Laplace's equation.
 ///

--- a/src/assembly/operators.rs
+++ b/src/assembly/operators.rs
@@ -183,7 +183,7 @@ where
 /// that represents some energy-like quantity *per unit volume*. Typically the elliptic energy
 /// arises in applications as the total potential energy over the domain
 ///
-/// $$ E[u] := \int_{\Omega} \psi (\nabla u) \dx. $$
+/// $$ E\[u\] := \int_{\Omega} \psi (\nabla u) \dx. $$
 ///
 /// The elliptic energy is then related to the elliptic operator
 /// $g: \mathbb{R}^{d \times s} \rightarrow \mathbb{R}^{d \times s}$ by the relation
@@ -200,7 +200,7 @@ where
 ///
 /// The simplest example of an elliptic energy is the
 /// [Dirichlet energy](https://en.wikipedia.org/wiki/Dirichlet_energy)
-/// $$ E[u] = \int_{\Omega} \frac{1}{2} \| \nabla u \|^2 \dx $$
+/// $$ E\[u\] = \int_{\Omega} \frac{1}{2} \| \nabla u \|^2 \dx $$
 /// where in our framework, $ \psi (\nabla u) = \frac{1}{2} \| \nabla u \|^2$ and
 /// $g = \nabla u$, which gives the weak form associated with Laplace's equation.
 ///

--- a/src/connectivity.rs
+++ b/src/connectivity.rs
@@ -636,7 +636,7 @@ where
 /// Connectivity for a 3D tri-quadratic Hex element.
 ///
 /// The node ordering is the same as defined by gmsh, see
-/// [http://gmsh.info/doc/texinfo/gmsh.html#Low-order-elements] for more information.
+/// <http://gmsh.info/doc/texinfo/gmsh.html#Low-order-elements> for more information.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Hex27Connectivity(pub [usize; 27]);
 
@@ -699,7 +699,7 @@ where
 /// Connectivity for a 3D 20-node Hex element.
 ///
 /// The node ordering is the same as defined by gmsh, see
-/// [http://gmsh.info/doc/texinfo/gmsh.html#Low-order-elements] for more information.
+/// <http://gmsh.info/doc/texinfo/gmsh.html#Low-order-elements> for more information.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Hex20Connectivity(pub [usize; 20]);
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -143,7 +143,7 @@ where
 
 /// "Analytic polar decomposition"
 ///
-/// Translated to Rust from https://github.com/InteractiveComputerGraphics/FastCorotatedFEM/blob/351b007b6bb6e8d97f457766e9ecf9b2bced7079/FastCorotFEM.cpp#L413
+/// Translated to Rust from <https://github.com/InteractiveComputerGraphics/FastCorotatedFEM/blob/351b007b6bb6e8d97f457766e9ecf9b2bced7079/FastCorotFEM.cpp#L413>
 ///
 /// ```
 /// use fenris::util::apd;


### PR DESCRIPTION
This PR adds an Actions workflow with the following steps
- Check formatting
- Cargo check
- Cargo doc (warnings as errors, we could change that)
- Cargo test without convergence tests
- Cargo test the convergence tests in release mode

Currently the actions cache the following directories:
```
      - uses: actions/cache@v2
        with:
          path: |
            ~/.cargo/bin/
            ~/.cargo/registry/index/
            ~/.cargo/registry/cache/
            ~/.cargo/git/db/
            target/
          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.toml') }}
```
The key implies that the cache will be rebuild as soon as a hash of any `Cargo.toml` changes, a new cache will be generated (old caches are deleted after 1 weeks of not using them I think).