### PR TITLE
Use consistent ordering of dim bounds

### DIFF
--- a/src/assembly/local/elliptic.rs
+++ b/src/assembly/local/elliptic.rs
@@ -30,7 +30,7 @@ where
     T: RealField,
     SolutionDim: DimName,
     GeometryDim: DimName,
-    DefaultAllocator: BiDimAllocator<T, GeometryDim, SolutionDim>,
+    DefaultAllocator: BiDimAllocator<T, SolutionDim, GeometryDim>,
 {
     let phi_grad_ref = phi_grad_ref.into();
     let u = u.into();
@@ -220,7 +220,7 @@ where
     Space: VolumetricFiniteElementSpace<T>,
     Op: EllipticEnergy<T, Space::ReferenceDim>,
     QTable: QuadratureTable<T, Space::ReferenceDim, Data = Op::Parameters> + ?Sized,
-    DefaultAllocator: TriDimAllocator<T, Space::GeometryDim, Space::ReferenceDim, Op::SolutionDim>,
+    DefaultAllocator: TriDimAllocator<T, Op::SolutionDim, Space::GeometryDim, Space::ReferenceDim>,
 {
     fn assemble_element_scalar(&self, element_index: usize) -> eyre::Result<T> {
         let s = self.solution_dim();
@@ -259,7 +259,7 @@ where
     Space: VolumetricFiniteElementSpace<T>,
     Op: EllipticOperator<T, Space::ReferenceDim>,
     QTable: QuadratureTable<T, Space::ReferenceDim, Data = Op::Parameters> + ?Sized,
-    DefaultAllocator: TriDimAllocator<T, Space::GeometryDim, Space::ReferenceDim, Op::SolutionDim>,
+    DefaultAllocator: TriDimAllocator<T, Op::SolutionDim, Space::GeometryDim, Space::ReferenceDim>,
 {
     #[allow(non_snake_case)]
     fn assemble_element_vector_into(&self, element_index: usize, output: DVectorSliceMut<T>) -> eyre::Result<()> {
@@ -301,7 +301,7 @@ where
     Space: VolumetricFiniteElementSpace<T>,
     Op: EllipticContraction<T, Space::ReferenceDim>,
     QTable: QuadratureTable<T, Space::ReferenceDim, Data = Op::Parameters> + ?Sized,
-    DefaultAllocator: TriDimAllocator<T, Space::GeometryDim, Space::ReferenceDim, Op::SolutionDim>,
+    DefaultAllocator: TriDimAllocator<T, Op::SolutionDim, Space::GeometryDim, Space::ReferenceDim>,
 {
     #[allow(non_snake_case)]
     fn assemble_element_matrix_into(&self, element_index: usize, output: DMatrixSliceMut<T>) -> eyre::Result<()> {
@@ -372,7 +372,7 @@ where
     // We only support volumetric elements atm
     Element: VolumetricFiniteElement<T>,
     Contraction: EllipticContraction<T, Element::GeometryDim>,
-    DefaultAllocator: BiDimAllocator<T, Element::GeometryDim, Contraction::SolutionDim>,
+    DefaultAllocator: BiDimAllocator<T, Contraction::SolutionDim, Element::GeometryDim>,
 {
     assert_eq!(quadrature_weights.len(), quadrature_points.len());
     assert_eq!(quadrature_points.len(), quadrature_data.len());
@@ -468,7 +468,7 @@ where
     // We only support volumetric elements atm
     Element: VolumetricFiniteElement<T>,
     Operator: EllipticOperator<T, Element::GeometryDim>,
-    DefaultAllocator: BiDimAllocator<T, Element::GeometryDim, Operator::SolutionDim>,
+    DefaultAllocator: BiDimAllocator<T, Operator::SolutionDim, Element::GeometryDim>,
 {
     assert_eq!(quadrature_weights.len(), quadrature_points.len());
     assert_eq!(quadrature_points.len(), quadrature_data.len());
@@ -562,7 +562,7 @@ where
     // We only support volumetric elements atm
     Element: VolumetricFiniteElement<T>,
     Operator: EllipticEnergy<T, Element::GeometryDim>,
-    DefaultAllocator: BiDimAllocator<T, Element::GeometryDim, Operator::SolutionDim>,
+    DefaultAllocator: BiDimAllocator<T, Operator::SolutionDim, Element::GeometryDim>,
 {
     let s = Operator::SolutionDim::dim();
     let n = element.num_nodes();

--- a/src/error.rs
+++ b/src/error.rs
@@ -30,7 +30,7 @@ where
     T: RealField,
     Element: VolumetricFiniteElement<T>,
     SolutionDim: SmallDim,
-    DefaultAllocator: TriDimAllocator<T, Element::GeometryDim, Element::ReferenceDim, SolutionDim>,
+    DefaultAllocator: TriDimAllocator<T, SolutionDim, Element::GeometryDim, Element::ReferenceDim>,
 {
     let n = element.num_nodes();
     assert_eq!(u_h_element.len(), n * SolutionDim::dim());
@@ -71,7 +71,7 @@ where
     T: RealField,
     Element: VolumetricFiniteElement<T>,
     SolutionDim: SmallDim,
-    DefaultAllocator: TriDimAllocator<T, Element::GeometryDim, Element::ReferenceDim, SolutionDim>,
+    DefaultAllocator: TriDimAllocator<T, SolutionDim, Element::GeometryDim, Element::ReferenceDim>,
 {
     let n = element.num_nodes();
     assert_eq!(u_h_element.len(), n * SolutionDim::dim());
@@ -121,7 +121,7 @@ where
     T: RealField,
     Element: VolumetricFiniteElement<T>,
     SolutionDim: SmallDim,
-    DefaultAllocator: TriDimAllocator<T, Element::GeometryDim, Element::ReferenceDim, SolutionDim>,
+    DefaultAllocator: TriDimAllocator<T, SolutionDim, Element::GeometryDim, Element::ReferenceDim>,
 {
     estimate_element_H1_seminorm_error_squared(
         element,
@@ -154,7 +154,7 @@ where
     T: RealField,
     Element: VolumetricFiniteElement<T>,
     SolutionDim: SmallDim,
-    DefaultAllocator: TriDimAllocator<T, Element::GeometryDim, Element::ReferenceDim, SolutionDim>,
+    DefaultAllocator: TriDimAllocator<T, SolutionDim, Element::GeometryDim, Element::ReferenceDim>,
 {
     estimate_element_L2_error_squared(
         element,
@@ -206,7 +206,7 @@ where
     SolutionDim: SmallDim,
     Space: VolumetricFiniteElementSpace<T>,
     QTable: QuadratureTable<T, Space::ReferenceDim>,
-    DefaultAllocator: TriDimAllocator<T, Space::GeometryDim, Space::ReferenceDim, SolutionDim>,
+    DefaultAllocator: TriDimAllocator<T, SolutionDim, Space::GeometryDim, Space::ReferenceDim>,
 {
     let u_h = u_h.into();
     let s = SolutionDim::dim();
@@ -253,7 +253,7 @@ where
     SolutionDim: SmallDim,
     Space: VolumetricFiniteElementSpace<T>,
     QTable: QuadratureTable<T, Space::ReferenceDim>,
-    DefaultAllocator: TriDimAllocator<T, Space::GeometryDim, Space::ReferenceDim, SolutionDim>,
+    DefaultAllocator: TriDimAllocator<T, SolutionDim, Space::GeometryDim, Space::ReferenceDim>,
 {
     Ok(estimate_L2_error_squared(space, u, u_h, qtable)?.sqrt())
 }
@@ -272,7 +272,7 @@ where
     SolutionDim: SmallDim,
     Space: VolumetricFiniteElementSpace<T>,
     QTable: QuadratureTable<T, Space::ReferenceDim>,
-    DefaultAllocator: TriDimAllocator<T, Space::GeometryDim, Space::ReferenceDim, SolutionDim>,
+    DefaultAllocator: TriDimAllocator<T, SolutionDim, Space::GeometryDim, Space::ReferenceDim>,
 {
     let u_h = u_h.into();
     let s = SolutionDim::dim();
@@ -319,7 +319,7 @@ where
     SolutionDim: SmallDim,
     Space: VolumetricFiniteElementSpace<T>,
     QTable: QuadratureTable<T, Space::ReferenceDim>,
-    DefaultAllocator: TriDimAllocator<T, Space::GeometryDim, Space::ReferenceDim, SolutionDim>,
+    DefaultAllocator: TriDimAllocator<T, SolutionDim, Space::GeometryDim, Space::ReferenceDim>,
 {
     estimate_H1_seminorm_error_squared(space, u_grad, u_h, qtable).map(|err2| err2.sqrt())
 }

--- a/tests/convergence_tests/poisson_mms_common.rs
+++ b/tests/convergence_tests/poisson_mms_common.rs
@@ -173,7 +173,7 @@ where
     Source: SourceFunction<f64, D, SolutionDim = U1, Parameters = ()> + Sync,
     // TODO: We should technically only require SmallDimAllocator<_, D>, but Rust gets type
     // inference wrong without this bound...
-    DefaultAllocator: TriDimAllocator<f64, D, D, U1>,
+    DefaultAllocator: TriDimAllocator<f64, U1, D, D>,
     <DefaultAllocator as Allocator<f64, D>>::Buffer: Sync,
 {
     let (a, b) = assemble_linear_system(&mesh, quadrature, poisson_source_function).unwrap();

--- a/tests/unit_tests/assembly/local/elliptic.rs
+++ b/tests/unit_tests/assembly/local/elliptic.rs
@@ -612,7 +612,7 @@ fn compute_energy_integral<Element, Energy>(
 where
     Element: VolumetricFiniteElement<f64>,
     Energy: EllipticEnergy<f64, Element::GeometryDim>,
-    DefaultAllocator: BiDimAllocator<f64, Element::GeometryDim, Energy::SolutionDim>,
+    DefaultAllocator: BiDimAllocator<f64, Energy::SolutionDim, Element::GeometryDim>,
 {
     let (weights, points) = quadrature;
 


### PR DESCRIPTION
This unfortunately seems important for type inference,
although I think it should not be necessary... Would be good to
investigate.