### PR TITLE
Update nalgebra to 0.31

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ serde_json = "1.0.64"
 
 [workspace]
 members = [
+    "fenris-traits",
     "fenris-quadrature",
     "fenris-geometry",
     "fenris-optimize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ default = [ ]
 proptest-support = [ "proptest", "fenris-geometry/proptest-support", "nalgebra/proptest-support" ]
 
 [dependencies]
-nalgebra = { version = "0.28", features = [ "serde-serialize" ] }
-nalgebra-sparse = { version = "0.4", features = ["compare"] }
+nalgebra = { version = "0.31", features = [ "serde-serialize" ] }
+nalgebra-sparse = { version = "0.7", features = ["compare"] }
 vtkio = "0.6"
 num = "0.4"
 numeric_literals = "0.2.0"
@@ -46,7 +46,7 @@ fenris-quadrature = { version="0.0.2", path = "fenris-quadrature" }
 
 [dev-dependencies]
 fenris = { path = ".", features = [ "proptest-support" ]}
-nalgebra = { version = "0.28", features = [ "serde-serialize", "compare" ] }
+nalgebra = { version = "0.31", features = [ "serde-serialize", "compare" ] }
 proptest = "1.0"
 matrixcompare = "0.3"
 util = { path = "util" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ log = "0.4"
 rustc-hash = "1.1.0"
 thread_local = "1.1.2"
 eyre = "0.6"
+fenris-traits = { version="0.0.1", path = "fenris-traits" }
 fenris-paradis = { version="0.0.1", path = "fenris-paradis" }
 fenris-nested-vec = { version="0.0.1", path = "fenris-nested-vec" }
 fenris-sparse = { version="0.0.1", path = "fenris-sparse" }

--- a/fenris-geometry/Cargo.toml
+++ b/fenris-geometry/Cargo.toml
@@ -12,7 +12,7 @@ proptest-support = [ "proptest", "nalgebra/proptest-support" ]
 
 [dependencies]
 itertools = "0.9"
-nalgebra = "0.28"
+nalgebra = "0.31"
 serde = { version="1.0", features = [ "derive" ] }
 numeric_literals = "0.2.0"
 fenris-nested-vec = { version = "0.0.1", path="../fenris-nested-vec" }
@@ -21,7 +21,7 @@ fenris-traits = { version = "0.0.1", path = "../fenris-traits" }
 
 [dev-dependencies]
 fenris-geometry = { path = ".", features = [ "proptest-support" ] }
-nalgebra = { version = "0.28", features = [ "compare", "rand" ]}
+nalgebra = { version = "0.31", features = [ "compare", "rand" ]}
 matrixcompare = { version="0.3", features = ["proptest-support"] }
 util = { path="../util" }
 fenris = { path = ".." }

--- a/fenris-geometry/Cargo.toml
+++ b/fenris-geometry/Cargo.toml
@@ -17,6 +17,7 @@ serde = { version="1.0", features = [ "derive" ] }
 numeric_literals = "0.2.0"
 fenris-nested-vec = { version = "0.0.1", path="../fenris-nested-vec" }
 proptest = { version="1.0", optional = true }
+fenris-traits = { version = "0.0.1", path = "../fenris-traits" }
 
 [dev-dependencies]
 fenris-geometry = { path = ".", features = [ "proptest-support" ] }

--- a/fenris-geometry/src/lib.rs
+++ b/fenris-geometry/src/lib.rs
@@ -413,7 +413,7 @@ pub trait ConvexPolygon3d<'a, T: Scalar>: Debug {
             // Point is *not* contained inside the extruded prism. Thus we must pick the
             // closest point on any of the edges of the polygon.
 
-            let mut closest_dist2 = T::max_value();
+            let mut closest_dist2 = T::max_value().unwrap();
             let mut closest_point = Point3::origin();
 
             for i in 0..self.num_vertices() {
@@ -450,7 +450,7 @@ pub trait ConvexPolyhedron<'a, T: Scalar>: Debug {
     {
         assert!(self.num_faces() >= 4, "Polyhedron must have at least 4 faces.");
         let mut inside = true;
-        let mut closest_dist = T::max_value();
+        let mut closest_dist = T::max_value().unwrap();
         let mut closest_point = Point3::origin();
         let mut closest_face_index = 0;
 

--- a/fenris-geometry/src/lib.rs
+++ b/fenris-geometry/src/lib.rs
@@ -1,7 +1,7 @@
+use fenris_traits::Real;
 use nalgebra::allocator::Allocator;
 use nalgebra::{
-    distance_squared, DefaultAllocator, DimName, OPoint, OVector, Point2, Point3, RealField, Scalar, Unit, Vector3, U2,
-    U3,
+    distance_squared, DefaultAllocator, DimName, OPoint, OVector, Point2, Point3, Scalar, Unit, Vector3, U2, U3,
 };
 use numeric_literals::replace_float_literals;
 use serde::{Deserialize, Serialize};
@@ -146,7 +146,7 @@ where
 
 impl<T, D> AxisAlignedBoundingBox<T, D>
 where
-    T: RealField,
+    T: Real,
     D: DimName,
     DefaultAllocator: Allocator<T, D>,
 {
@@ -241,13 +241,13 @@ where
     }
 }
 
-fn intervals_intersect<T: RealField>([l1, u1]: [T; 2], [l2, u2]: [T; 2]) -> bool {
+fn intervals_intersect<T: Real>([l1, u1]: [T; 2], [l2, u2]: [T; 2]) -> bool {
     l2 <= u1 && u2 >= l1
 }
 
 impl<T, D> BoundedGeometry<T> for AxisAlignedBoundingBox<T, D>
 where
-    T: RealField,
+    T: Real,
     D: DimName,
     DefaultAllocator: Allocator<T, D>,
 {
@@ -303,7 +303,7 @@ pub trait ConvexPolygon3d<'a, T: Scalar>: Debug {
 
     fn compute_plane(&self) -> Option<Plane<T>>
     where
-        T: RealField,
+        T: Real,
     {
         let normal = self.compute_normal();
         let point = self.get_vertex(0)?;
@@ -312,7 +312,7 @@ pub trait ConvexPolygon3d<'a, T: Scalar>: Debug {
 
     fn compute_half_space(&self) -> Option<HalfSpace<T>>
     where
-        T: RealField,
+        T: Real,
     {
         let normal = self.compute_normal();
         let point = self.get_vertex(0)?;
@@ -327,7 +327,7 @@ pub trait ConvexPolygon3d<'a, T: Scalar>: Debug {
     #[replace_float_literals(T::from_f64(literal).unwrap())]
     fn compute_area_vector(&self) -> Vector3<T>
     where
-        T: RealField,
+        T: Real,
     {
         assert!(self.num_vertices() >= 3, "Polygons must have at least 3 vertices.");
 
@@ -348,7 +348,7 @@ pub trait ConvexPolygon3d<'a, T: Scalar>: Debug {
     /// Computes an outwards-facing normalized vector perpendicular to the polygon.
     fn compute_normal(&self) -> Vector3<T>
     where
-        T: RealField,
+        T: Real,
     {
         // In principle, we could compute the face normal simply by
         // taking the cross product of the first two segments. However, the first M segments
@@ -365,7 +365,7 @@ pub trait ConvexPolygon3d<'a, T: Scalar>: Debug {
 
     fn closest_point(&self, point: &Point3<T>) -> PolygonClosestPoint<T, U3>
     where
-        T: RealField,
+        T: Real,
     {
         assert!(self.num_vertices() >= 3, "Polygon must have at least 3 vertices.");
 
@@ -446,7 +446,7 @@ pub trait ConvexPolyhedron<'a, T: Scalar>: Debug {
     #[replace_float_literals(T::from_f64(literal).unwrap())]
     fn compute_signed_distance(&self, point: &Point3<T>) -> SignedDistanceResult<T, U3>
     where
-        T: RealField,
+        T: Real,
     {
         assert!(self.num_faces() >= 4, "Polyhedron must have at least 4 faces.");
         let mut inside = true;
@@ -486,7 +486,7 @@ pub trait ConvexPolyhedron<'a, T: Scalar>: Debug {
 
     fn compute_volume(&'a self) -> T
     where
-        T: RealField,
+        T: Real,
     {
         let faces = (0..self.num_faces()).map(move |idx| {
             self.get_face(idx)
@@ -500,7 +500,7 @@ pub trait ConvexPolyhedron<'a, T: Scalar>: Debug {
     /// TODO: Write tests
     fn contains_point(&'a self, point: &Point3<T>) -> bool
     where
-        T: RealField,
+        T: Real,
     {
         // The convex polyhedron contains the point if all half-spaces associated with
         // faces contain the point
@@ -524,7 +524,7 @@ pub trait ConvexPolyhedron<'a, T: Scalar>: Debug {
 #[replace_float_literals(T::from_f64(literal).unwrap())]
 pub fn compute_polyhedron_volume_from_faces<'a, T, F>(boundary_faces: impl 'a + IntoIterator<Item = F>) -> T
 where
-    T: RealField,
+    T: Real,
     F: ConvexPolygon3d<'a, T>,
 {
     // We use the formula given on the Wikipedia page for Polyhedra:
@@ -557,7 +557,7 @@ where
 // TODO: Actually implement SignedDistance for Tetrahedron
 //impl<T> SignedDistance<T, U3> for Tetrahedron<T>
 //where
-//    T: RealField
+//    T: Real
 //{
 //    #[replace_float_literals(T::from_f64(literal).unwrap())]
 //    fn query_signed_distance(&self, point: &Point3<T>) -> Option<SignedDistanceResult<T, U3>> {
@@ -608,7 +608,7 @@ where
 
 impl<T> TryFrom<Quad2d<T>> for ConvexPolygon<T>
 where
-    T: RealField,
+    T: Real,
 {
     type Error = ConcavePolygonError;
 

--- a/fenris-geometry/src/polygon.rs
+++ b/fenris-geometry/src/polygon.rs
@@ -70,7 +70,8 @@ where
 
     fn closest_edge(&self, x: &Point2<T>) -> Option<ClosestEdge<T>> {
         let mut closest_edge_index = None;
-        let mut smallest_squared_dist = T::max_value();
+        // TODO: Fix unwrap
+        let mut smallest_squared_dist = T::max_value().unwrap();
 
         self.for_each_edge(|edge_idx, edge| {
             let closest_point_on_edge = edge.closest_point(x);
@@ -116,7 +117,8 @@ where
         }
 
         let mut closest_edges = [0, 0];
-        let mut smallest_squared_dists = [T::max_value(), T::max_value()];
+        // TODO: Fix unwraps
+        let mut smallest_squared_dists = [T::max_value().unwrap(), T::max_value().unwrap()];
         let endpoints = [*segment.start(), *segment.end()];
 
         let mut intersects = false;

--- a/fenris-geometry/src/polygon.rs
+++ b/fenris-geometry/src/polygon.rs
@@ -2,11 +2,10 @@ use crate::{
     AxisAlignedBoundingBox, BoundedGeometry, Convex, Distance, HalfSpace, LineSegment2d, LineSegment3d, Orientation,
     Triangle,
 };
+use fenris_traits::Real;
 use itertools::{izip, Itertools};
 use nalgebra::allocator::Allocator;
-use nalgebra::{
-    clamp, DefaultAllocator, DimName, Isometry3, OPoint, Point2, Point3, RealField, Scalar, Vector2, Vector3, U2, U3,
-};
+use nalgebra::{clamp, DefaultAllocator, DimName, Isometry3, OPoint, Point2, Point3, Scalar, Vector2, Vector3, U2, U3};
 use serde::{Deserialize, Serialize};
 use std::iter::once;
 
@@ -40,7 +39,7 @@ where
 
 pub trait Polygon2d<T>
 where
-    T: RealField,
+    T: Real,
 {
     fn vertices(&self) -> &[Point2<T>];
 
@@ -230,7 +229,7 @@ where
     }
 }
 
-impl<T: RealField> SimplePolygon2d<T> {
+impl<T: Real> SimplePolygon2d<T> {
     /// Apply a similarity transform in order to construct a 3D simple polygon.
     ///
     /// Each 2D vertex is implicitly assumed to have z coordinate 0.
@@ -244,7 +243,7 @@ impl<T: RealField> SimplePolygon2d<T> {
     }
 }
 
-impl<T: RealField> SimplePolygon3d<T> {
+impl<T: Real> SimplePolygon3d<T> {
     #[replace_float_literals(T::from_f64(literal).unwrap())]
     pub fn area_vector(&self) -> Vector3<T> {
         let vertices = self.vertices();
@@ -320,7 +319,7 @@ where
 
 impl<T> Polygon2d<T> for SimplePolygon2d<T>
 where
-    T: RealField,
+    T: Real,
 {
     fn vertices(&self) -> &[Point2<T>] {
         &self.vertices
@@ -365,7 +364,7 @@ where
 
 impl<T, D> BoundedGeometry<T> for SimplePolygon<T, D>
 where
-    T: RealField,
+    T: Real,
     D: DimName,
     DefaultAllocator: Allocator<T, D>,
 {
@@ -378,7 +377,7 @@ where
 
 impl<T> Distance<T, Point2<T>> for SimplePolygon2d<T>
 where
-    T: RealField,
+    T: Real,
 {
     fn distance(&self, point: &Point2<T>) -> T {
         let closest_edge = self

--- a/fenris-geometry/src/polymesh.rs
+++ b/fenris-geometry/src/polymesh.rs
@@ -1,6 +1,7 @@
+use fenris_traits::Real;
 use itertools::Itertools;
 use nalgebra::allocator::Allocator;
-use nalgebra::{DefaultAllocator, DimName, OPoint, Point3, RealField, Scalar, Vector3, U3};
+use nalgebra::{DefaultAllocator, DimName, OPoint, Point3, Scalar, Vector3, U3};
 use numeric_literals::replace_float_literals;
 use serde::{Deserialize, Serialize};
 use std::cmp::{max, min};
@@ -276,7 +277,7 @@ where
 
 impl<T, D> PolyMesh<T, D>
 where
-    T: RealField,
+    T: Real,
     D: DimName,
     DefaultAllocator: Allocator<T, D>,
 {
@@ -504,7 +505,7 @@ where
 ///
 /// More precisely, given N vertices, a vector of N boolean values is returned.
 /// If element `i` is `true`, then vertex `i` is contained in the half space.
-fn mark_vertices<T: RealField>(vertices: &[Point3<T>], half_space: &HalfSpace<T>) -> Vec<bool> {
+fn mark_vertices<T: Real>(vertices: &[Point3<T>], half_space: &HalfSpace<T>) -> Vec<bool> {
     vertices
         .iter()
         .map(|v| half_space.contains_point(v))
@@ -537,7 +538,7 @@ fn is_intersection_vertex(vertex_edge_representation: &UndirectedEdge) -> bool {
 
 impl<T> PolyMesh3d<T>
 where
-    T: RealField,
+    T: Real,
 {
     pub fn translate(&mut self, translation: &Vector3<T>) {
         for v in self.vertices_mut() {

--- a/fenris-geometry/src/polytope.rs
+++ b/fenris-geometry/src/polytope.rs
@@ -1,6 +1,7 @@
 use crate::{HalfPlane, Line2d, LineSegment2d, SimplePolygon2d, Triangle, Triangle2d};
+use fenris_traits::Real;
 use itertools::Itertools;
-use nalgebra::{Point2, RealField, Scalar, Unit, Vector2};
+use nalgebra::{Point2, Scalar, Unit, Vector2};
 
 /// Type used to indicate conversion failure in the presence of concavity.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -72,7 +73,7 @@ where
 
 impl<T> ConvexPolygon<T>
 where
-    T: RealField,
+    T: Real,
 {
     /// Iterates over the half planes that define the polygon.
     ///

--- a/fenris-geometry/src/primitives/half_space.rs
+++ b/fenris-geometry/src/primitives/half_space.rs
@@ -1,6 +1,7 @@
 use crate::{Line2d, Plane};
+use fenris_traits::Real;
 use nalgebra::allocator::Allocator;
-use nalgebra::{DefaultAllocator, DimName, OPoint, OVector, RealField, Scalar, Unit, Vector2, U2, U3};
+use nalgebra::{DefaultAllocator, DimName, OPoint, OVector, Scalar, Unit, Vector2, U2, U3};
 
 /// A $D$-dimensional half space.
 ///
@@ -25,7 +26,7 @@ pub type HalfPlane<T> = HalfSpace<T, U2>;
 
 impl<T, D> HalfSpace<T, D>
 where
-    T: RealField,
+    T: Real,
     D: DimName,
     DefaultAllocator: Allocator<T, D>,
 {
@@ -60,7 +61,7 @@ where
 
 impl<T> HalfSpace<T>
 where
-    T: RealField,
+    T: Real,
 {
     pub fn plane(&self) -> Plane<T> {
         Plane::from_point_and_normal(self.point, self.normal)
@@ -73,7 +74,7 @@ where
 
 impl<T> HalfPlane<T>
 where
-    T: RealField,
+    T: Real,
 {
     /// Returns a line representing the surface of the half plane
     pub fn surface(&self) -> Line2d<T> {

--- a/fenris-geometry/src/primitives/hexahedron.rs
+++ b/fenris-geometry/src/primitives/hexahedron.rs
@@ -1,7 +1,8 @@
 use crate::{
     AxisAlignedBoundingBox, BoundedGeometry, ConvexPolyhedron, Distance, Quad3d, SignedDistance, SignedDistanceResult,
 };
-use nalgebra::{OPoint, Point3, RealField, Scalar, U3};
+use fenris_traits::Real;
+use nalgebra::{OPoint, Point3, Scalar, U3};
 use numeric_literals::replace_float_literals;
 
 #[derive(Debug, Copy, Clone, PartialEq, Hash)]
@@ -15,7 +16,7 @@ where
 
 impl<T> BoundedGeometry<T> for Hexahedron<T>
 where
-    T: RealField,
+    T: Real,
 {
     type Dimension = U3;
 
@@ -35,7 +36,7 @@ where
 
 impl<T> Hexahedron<T>
 where
-    T: RealField,
+    T: Real,
 {
     #[replace_float_literals(T::from_f64(literal).unwrap())]
     pub fn reference() -> Self {
@@ -54,7 +55,7 @@ where
 
 impl<T> Distance<T, Point3<T>> for Hexahedron<T>
 where
-    T: RealField,
+    T: Real,
 {
     fn distance(&self, point: &Point3<T>) -> T {
         let signed_dist = self.compute_signed_distance(point).signed_distance;
@@ -64,7 +65,7 @@ where
 
 impl<T> SignedDistance<T, U3> for Hexahedron<T>
 where
-    T: RealField,
+    T: Real,
 {
     fn query_signed_distance(&self, point: &OPoint<T, U3>) -> Option<SignedDistanceResult<T, U3>> {
         Some(self.compute_signed_distance(point))
@@ -73,7 +74,7 @@ where
 
 impl<'a, T> ConvexPolyhedron<'a, T> for Hexahedron<T>
 where
-    T: RealField,
+    T: Real,
 {
     type Face = Quad3d<T>;
 

--- a/fenris-geometry/src/primitives/line.rs
+++ b/fenris-geometry/src/primitives/line.rs
@@ -1,13 +1,14 @@
 use crate::{ConvexPolygon, Disk, HalfPlane, Plane};
+use fenris_traits::Real;
 use nalgebra::allocator::Allocator;
-use nalgebra::{clamp, DefaultAllocator, DimName, Matrix2, OPoint, OVector, RealField, Vector2, U2, U3};
+use nalgebra::{clamp, DefaultAllocator, DimName, Matrix2, OPoint, OVector, Vector2, U2, U3};
 use nalgebra::{Point2, Point3, Scalar};
 use numeric_literals::replace_float_literals;
 use std::fmt::Debug;
 
 pub type LineSegment3d<T> = LineSegment<T, U3>;
 
-impl<T: RealField> LineSegment3d<T> {
+impl<T: Real> LineSegment3d<T> {
     #[allow(non_snake_case)]
     pub fn closest_point_to_plane_parametric(&self, plane: &Plane<T>) -> T {
         let n = plane.normal();
@@ -85,7 +86,7 @@ where
 
 impl<T, D> LineSegment<T, D>
 where
-    T: RealField,
+    T: Real,
     D: DimName,
     DefaultAllocator: Allocator<T, D>,
 {
@@ -129,7 +130,7 @@ where
 
 impl<T> LineSegment2d<T>
 where
-    T: RealField,
+    T: Real,
 {
     /// Returns a vector normal to the line segment, in the direction consistent with a
     /// counter-clockwise winding order when the edge is part of a polygon.
@@ -260,7 +261,7 @@ where
     }
 }
 
-impl<T: RealField> LineSegment3d<T> {
+impl<T: Real> LineSegment3d<T> {
     pub fn intersect_plane_parametric(&self, plane: &Plane<T>) -> Option<T> {
         self.to_line()
             .intersect_plane_parametric(plane)
@@ -304,7 +305,7 @@ where
 
 impl<T, D> Line<T, D>
 where
-    T: RealField,
+    T: Real,
     D: DimName,
     DefaultAllocator: Allocator<T, D>,
 {
@@ -345,7 +346,7 @@ where
 
 impl<T> Line2d<T>
 where
-    T: RealField,
+    T: Real,
 {
     pub fn intersect(&self, other: &Line2d<T>) -> Option<Point2<T>> {
         self.intersect_line_parametric(other)
@@ -414,7 +415,7 @@ where
 
 impl<T> Line3d<T>
 where
-    T: RealField,
+    T: Real,
 {
     pub fn intersect_plane_parametric(&self, plane: &Plane<T>) -> Option<T> {
         let n = plane.normal();

--- a/fenris-geometry/src/primitives/plane.rs
+++ b/fenris-geometry/src/primitives/plane.rs
@@ -1,4 +1,5 @@
-use nalgebra::{Point3, RealField, Scalar, Unit, UnitVector3, Vector3};
+use fenris_traits::Real;
+use nalgebra::{Point3, Scalar, Unit, UnitVector3, Vector3};
 
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct Plane<T: Scalar> {
@@ -8,7 +9,7 @@ pub struct Plane<T: Scalar> {
 
 impl<T> Plane<T>
 where
-    T: RealField,
+    T: Real,
 {
     pub fn normal(&self) -> &Unit<Vector3<T>> {
         &self.normal

--- a/fenris-geometry/src/primitives/quad.rs
+++ b/fenris-geometry/src/primitives/quad.rs
@@ -1,8 +1,9 @@
 use crate::{
     AxisAlignedBoundingBox2d, BoundedGeometry, ConvexPolygon3d, Distance, SimplePolygon2d, Triangle, Triangle2d,
 };
+use fenris_traits::Real;
 use itertools::izip;
-use nalgebra::{Point2, Point3, RealField, Scalar, U2};
+use nalgebra::{Point2, Point3, Scalar, U2};
 
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct Quad3d<T: Scalar> {
@@ -30,7 +31,7 @@ where
 
 impl<T> BoundedGeometry<T> for Quad2d<T>
 where
-    T: RealField,
+    T: Real,
 {
     type Dimension = U2;
 
@@ -46,7 +47,7 @@ pub struct Quad2d<T: Scalar>(pub [Point2<T>; 4]);
 
 impl<T> Quad2d<T>
 where
-    T: RealField,
+    T: Real,
 {
     /// Returns the index of a concave corner of the quadrilateral, if there is any.
     pub fn concave_corner(&self) -> Option<usize> {
@@ -113,7 +114,7 @@ where
 
 impl<T> Distance<T, Point2<T>> for Quad2d<T>
 where
-    T: RealField,
+    T: Real,
 {
     fn distance(&self, point: &Point2<T>) -> T {
         // TODO: Avoid heap allocation

--- a/fenris-geometry/src/primitives/tetrahedron.rs
+++ b/fenris-geometry/src/primitives/tetrahedron.rs
@@ -1,7 +1,7 @@
 use crate::{
     AxisAlignedBoundingBox, BoundedGeometry, ConvexPolyhedron, Distance, OrientationTestResult, Triangle, Triangle3d,
 };
-use nalgebra::RealField;
+use fenris_traits::Real;
 use nalgebra::{OPoint, Point3, Scalar, U3};
 use numeric_literals::replace_float_literals;
 use serde::{Deserialize, Serialize};
@@ -32,7 +32,7 @@ where
 
 impl<T> Tetrahedron<T>
 where
-    T: RealField,
+    T: Real,
 {
     /// Reference tetrahedron.
     #[replace_float_literals(T::from_f64(literal).unwrap())]
@@ -46,7 +46,7 @@ where
     }
 }
 
-impl<T: RealField> BoundedGeometry<T> for Tetrahedron<T> {
+impl<T: Real> BoundedGeometry<T> for Tetrahedron<T> {
     type Dimension = U3;
 
     fn bounding_box(&self) -> AxisAlignedBoundingBox<T, U3> {
@@ -56,7 +56,7 @@ impl<T: RealField> BoundedGeometry<T> for Tetrahedron<T> {
 
 impl<'a, T> ConvexPolyhedron<'a, T> for Tetrahedron<T>
 where
-    T: RealField,
+    T: Real,
 {
     type Face = Triangle3d<T>;
 
@@ -81,7 +81,7 @@ where
 
 impl<T> Distance<T, Point3<T>> for Tetrahedron<T>
 where
-    T: RealField,
+    T: Real,
 {
     fn distance(&self, point: &OPoint<T, U3>) -> T {
         let triangle = |i, j, k| Triangle([self.vertices[i], self.vertices[j], self.vertices[k]]);

--- a/fenris-geometry/src/primitives/tetrahedron.rs
+++ b/fenris-geometry/src/primitives/tetrahedron.rs
@@ -96,7 +96,8 @@ where
         ];
 
         let mut point_inside = true;
-        let mut min_dist = T::max_value();
+        // TODO: Fix unwrap
+        let mut min_dist = T::max_value().unwrap();
 
         for tri_face in &tri_faces {
             // Remember that the triangles are oriented such that *outwards* is the positive

--- a/fenris-geometry/src/primitives/triangle.rs
+++ b/fenris-geometry/src/primitives/triangle.rs
@@ -2,9 +2,10 @@ use crate::{
     AxisAlignedBoundingBox, BoundedGeometry, ConvexPolygon3d, Distance, LineSegment2d, Orientation,
     OrientationTestResult, SignedDistance, SignedDistanceResult,
 };
+use fenris_traits::Real;
 use nalgebra::allocator::Allocator;
+use nalgebra::Matrix3;
 use nalgebra::{DefaultAllocator, DimName, OPoint, OVector, Point2, Point3, Scalar, Vector3, U2, U3};
-use nalgebra::{Matrix3, RealField};
 use numeric_literals::replace_float_literals;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
@@ -50,7 +51,7 @@ where
 
 impl<T, D> Triangle<T, D>
 where
-    T: RealField,
+    T: Real,
     D: DimName,
     DefaultAllocator: Allocator<T, D>,
 {
@@ -73,7 +74,7 @@ where
 
 impl<T> Triangle2d<T>
 where
-    T: RealField,
+    T: Real,
 {
     pub fn orientation(&self) -> Orientation {
         if self.signed_area() >= T::zero() {
@@ -100,7 +101,7 @@ where
 
 impl<T> Triangle3d<T>
 where
-    T: RealField,
+    T: Real,
 {
     /// Returns a vector normal to the triangle. The vector is *not* normalized.
     pub fn normal_dir(&self) -> Vector3<T> {
@@ -171,7 +172,7 @@ where
 
 impl<T, D> BoundedGeometry<T> for Triangle<T, D>
 where
-    T: RealField,
+    T: Real,
     D: DimName,
     DefaultAllocator: Allocator<T, D>,
 {
@@ -184,7 +185,7 @@ where
 
 impl<T> Distance<T, Point2<T>> for Triangle2d<T>
 where
-    T: RealField,
+    T: Real,
 {
     fn distance(&self, point: &Point2<T>) -> T {
         let sdf = self.query_signed_distance(point).unwrap();
@@ -194,7 +195,7 @@ where
 
 impl<T> SignedDistance<T, U2> for Triangle2d<T>
 where
-    T: RealField,
+    T: Real,
 {
     fn query_signed_distance(&self, point: &Point2<T>) -> Option<SignedDistanceResult<T, U2>> {
         // TODO: This is not the most efficient way to compute this
@@ -238,7 +239,7 @@ where
 
 impl<T> Distance<T, Point3<T>> for Triangle3d<T>
 where
-    T: RealField,
+    T: Real,
 {
     #[replace_float_literals(T::from_f64(literal).unwrap())]
     fn distance(&self, point: &OPoint<T, U3>) -> T {
@@ -246,7 +247,7 @@ where
     }
 }
 
-impl<'a, T: RealField> ConvexPolygon3d<'a, T> for Triangle3d<T> {
+impl<'a, T: Real> ConvexPolygon3d<'a, T> for Triangle3d<T> {
     fn num_vertices(&self) -> usize {
         3
     }
@@ -256,7 +257,7 @@ impl<'a, T: RealField> ConvexPolygon3d<'a, T> for Triangle3d<T> {
     }
 }
 
-impl<T: RealField> Triangle3d<T> {
+impl<T: Real> Triangle3d<T> {
     /// Compute the solid angle to the given point.
     #[replace_float_literals(T::from_f64(literal).unwrap())]
     pub fn compute_solid_angle(&self, p: &Point3<T>) -> T {
@@ -278,7 +279,7 @@ impl<T: RealField> Triangle3d<T> {
 #[replace_float_literals(T::from_f64(literal).unwrap())]
 pub fn compute_winding_number_for_triangles_3d<T, I>(triangles: I, point: &Point3<T>) -> T
 where
-    T: RealField,
+    T: Real,
     I: IntoIterator<Item = Triangle3d<T>>,
 {
     let angle_sum = triangles

--- a/fenris-geometry/src/primitives/triangle.rs
+++ b/fenris-geometry/src/primitives/triangle.rs
@@ -202,7 +202,8 @@ where
         let mut inside = true;
 
         let mut closest_segment = 0;
-        let mut closest_dist2 = T::max_value();
+        // TODO: Fix unwrap
+        let mut closest_dist2 = T::max_value().unwrap();
         let mut closest_point = Point2::origin();
 
         // We assume counterclockwise orientation.

--- a/fenris-geometry/src/sdf.rs
+++ b/fenris-geometry/src/sdf.rs
@@ -1,4 +1,5 @@
-use nalgebra::{Point2, RealField, Scalar, Vector2, U2};
+use fenris_traits::Real;
+use nalgebra::{Point2, Scalar, Vector2, U2};
 
 use crate::{AxisAlignedBoundingBox2d, BoundedGeometry};
 use numeric_literals::replace_float_literals;
@@ -60,7 +61,7 @@ where
 
 impl<T> BoundedGeometry<T> for SdfCircle<T>
 where
-    T: RealField,
+    T: Real,
 {
     type Dimension = U2;
 
@@ -75,7 +76,7 @@ where
 
 impl<T> SignedDistanceFunction2d<T> for SdfCircle<T>
 where
-    T: RealField,
+    T: Real,
 {
     fn eval(&self, x: &Point2<T>) -> T {
         let y = x - self.center;
@@ -96,7 +97,7 @@ where
 
 impl<T, Left, Right> BoundedGeometry<T> for SdfUnion<Left, Right>
 where
-    T: RealField,
+    T: Real,
     Left: BoundedGeometry<T, Dimension = U2>,
     Right: BoundedGeometry<T, Dimension = U2>,
 {
@@ -109,7 +110,7 @@ where
 
 impl<T, Left, Right> SignedDistanceFunction2d<T> for SdfUnion<Left, Right>
 where
-    T: RealField,
+    T: Real,
     Left: SignedDistanceFunction2d<T>,
     Right: SignedDistanceFunction2d<T>,
 {
@@ -130,7 +131,7 @@ where
 
 impl<T> BoundedGeometry<T> for SdfAxisAlignedBox<T>
 where
-    T: RealField,
+    T: Real,
 {
     type Dimension = U2;
 
@@ -141,7 +142,7 @@ where
 
 impl<T> SignedDistanceFunction2d<T> for SdfAxisAlignedBox<T>
 where
-    T: RealField,
+    T: Real,
 {
     #[replace_float_literals(T::from_f64(literal).unwrap())]
     fn eval(&self, x: &Point2<T>) -> T {

--- a/fenris-geometry/src/util.rs
+++ b/fenris-geometry/src/util.rs
@@ -1,6 +1,7 @@
-use nalgebra::{RealField, UnitVector3, Vector3};
+use fenris_traits::Real;
+use nalgebra::{UnitVector3, Vector3};
 
-pub fn compute_orthonormal_vectors_3d<T: RealField>(vector: &UnitVector3<T>) -> [UnitVector3<T>; 2] {
+pub fn compute_orthonormal_vectors_3d<T: Real>(vector: &UnitVector3<T>) -> [UnitVector3<T>; 2] {
     // Ported from
     // https://github.com/dimforge/parry/blob/ac8dcf0197066cd2413a20e4420961b4694996c0/src/utils/wops.rs#L120-L138
     // originally based on the Pixar paper "Building an Orthonormal Basis, Revisited",

--- a/fenris-geometry/src/vtkio.rs
+++ b/fenris-geometry/src/vtkio.rs
@@ -7,7 +7,7 @@
 // use crate::{ConvexPolygon, GeneralPolygon};
 // use ::vtkio::model::{Attributes, Cells, DataSet, PolyDataTopology};
 // use nalgebra::allocator::Allocator;
-// use nalgebra::{DefaultAllocator, DimName, OPoint, RealField, Scalar};
+// use nalgebra::{DefaultAllocator, DimName, OPoint, Real, Scalar};
 // use num::Zero;
 // use std::fs::create_dir_all;
 // use std::path::Path;
@@ -162,7 +162,7 @@
 //
 // impl<'a, T> From<&'a GeneralPolygon<T>> for DataSet
 // where
-//     T: RealField,
+//     T: Real,
 // {
 //     fn from(polygon: &'a GeneralPolygon<T>) -> Self {
 //         let mut points = Vec::with_capacity(polygon.num_vertices() * 3);

--- a/fenris-geometry/tests/unit_tests/polygon.rs
+++ b/fenris-geometry/tests/unit_tests/polygon.rs
@@ -1,6 +1,6 @@
 use fenris_geometry::{HalfSpace, LineSegment2d, Polygon2d, SimplePolygon2d, SimplePolygon3d, Triangle};
 use matrixcompare::{assert_matrix_eq, assert_scalar_eq};
-use nalgebra::{clamp, point, vector, Isometry3, Point2, Point3, Vector2, Vector3, Unit};
+use nalgebra::{clamp, point, vector, Isometry3, Point2, Point3, Unit, Vector2, Vector3};
 
 use fenris::eyre;
 use fenris::vtkio::model::{Attribute, Attributes, ByteOrder, DataSet, PolyDataPiece, Version, VertexNumbers};
@@ -318,38 +318,25 @@ fn simple_polygon_3d_intersect_half_space() {
 #[allow(dead_code)]
 fn simple_polygon_3d_intersect_half_space_manual_examples() {
     let polygon = SimplePolygon3d::from_vertices(vec![
-        point![
-                        0.9275983957221751,
-                        0.9885787695417991,
-                        0.7871816125737546
-                    ],
-        point![
-                        0.08245163203498629,
-                        0.06270868532434581,
-                        0.9151752915888964
-                    ],
-        point![
-                        0.3874741082479616,
-                        0.7451139603007322,
-                        0.8095833026585179
-        ],
+        point![0.9275983957221751, 0.9885787695417991, 0.7871816125737546],
+        point![0.08245163203498629, 0.06270868532434581, 0.9151752915888964],
+        point![0.3874741082479616, 0.7451139603007322, 0.8095833026585179],
     ]);
-    let p = point![
-        0.547635183063019,
-        0.7008502553033911,
-        0.7983885368267101
-    ];
-    let n = vector![-0.27472249471876764,
-                    0.8760796727967517,
-                    -0.39624734422811364];
+    let p = point![0.547635183063019, 0.7008502553033911, 0.7983885368267101];
+    let n = vector![-0.27472249471876764, 0.8760796727967517, -0.39624734422811364];
 
     let half_space = HalfSpace::from_point_and_normal(p, Unit::new_unchecked(n));
 
     // TODO: Remove
     {
-        let contains: Vec<_> = polygon.vertices().iter()
-            .map(|v| half_space.contains_point(&v)).collect();
-        let signed_distances: Vec<_> = polygon.vertices().iter()
+        let contains: Vec<_> = polygon
+            .vertices()
+            .iter()
+            .map(|v| half_space.contains_point(&v))
+            .collect();
+        let signed_distances: Vec<_> = polygon
+            .vertices()
+            .iter()
             .map(|v| half_space.signed_distance_to_point(v))
             .collect();
         dbg!(contains);
@@ -358,16 +345,8 @@ fn simple_polygon_3d_intersect_half_space_manual_examples() {
 
     let intersection = polygon.intersect_half_space(&half_space);
 
-    let p2 = point![
-        0.4926906841192654,
-                    0.8760661898627415,
-                    0.7191390679810874
-    ];
-    let n2 = vector![
-                    0.27472249471876764,
-                    -0.8760796727967517,
-                    0.39624734422811364
-                ];
+    let p2 = point![0.4926906841192654, 0.8760661898627415, 0.7191390679810874];
+    let n2 = vector![0.27472249471876764, -0.8760796727967517, 0.39624734422811364];
     let half_space2 = HalfSpace::from_point_and_normal(p2, Unit::new_unchecked(n2));
     let intersection2 = intersection.intersect_half_space(&half_space2);
 
@@ -434,9 +413,7 @@ fn simple_polygon_3d_vtk_data_set(polygon: &SimplePolygon3d<f64>) -> DataSet {
     }
     poly_offsets.push(connectivity.len() as u64);
 
-
-    let normal_data = Attribute::normals("Normals")
-        .with_data(vertex_normal_data);
+    let normal_data = Attribute::normals("Normals").with_data(vertex_normal_data);
 
     let piece = PolyDataPiece {
         points: vertex_buffer.into(),
@@ -454,7 +431,7 @@ fn simple_polygon_3d_vtk_data_set(polygon: &SimplePolygon3d<f64>) -> DataSet {
         data: Attributes {
             point: vec![normal_data],
             cell: vec![],
-        }
+        },
     };
 
     DataSet::from(piece)

--- a/fenris-optimize/Cargo.toml
+++ b/fenris-optimize/Cargo.toml
@@ -9,7 +9,7 @@ description = "Optimization functionality used by fenris"
 
 [dependencies]
 fenris-traits = { version="0.0.1", path = "../fenris-traits" }
-nalgebra = { version = "0.28", features = ["compare"] }
+nalgebra = { version = "0.31", features = ["compare"] }
 numeric_literals = "0.2.0"
 itertools = "0.9"
 log = "0.4"

--- a/fenris-optimize/Cargo.toml
+++ b/fenris-optimize/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/InteractiveComputerGraphics/fenris"
 description = "Optimization functionality used by fenris"
 
 [dependencies]
+fenris-traits = { version="0.0.1", path = "../fenris-traits" }
 nalgebra = { version = "0.28", features = ["compare"] }
 numeric_literals = "0.2.0"
 itertools = "0.9"

--- a/fenris-optimize/src/calculus.rs
+++ b/fenris-optimize/src/calculus.rs
@@ -1,6 +1,6 @@
+use fenris_traits::Real;
 use nalgebra::{
-    DMatrix, DMatrixSliceMut, DVector, DVectorSlice, DVectorSliceMut, Dim, DimName, Dynamic, RealField, Scalar, Vector,
-    U1,
+    DMatrix, DMatrixSliceMut, DVector, DVectorSlice, DVectorSliceMut, Dim, DimName, Dynamic, Scalar, Vector, U1,
 };
 
 use nalgebra::base::storage::{Storage, StorageMut};
@@ -157,7 +157,7 @@ where
 #[replace_float_literals(T::from_f64(literal).expect("Literal must fit in T"))]
 pub fn approximate_jacobian<T>(mut f: impl VectorFunction<T>, x: &DVector<T>, h: &T) -> DMatrix<T>
 where
-    T: RealField,
+    T: Real,
 {
     let out_dim = f.dimension();
     let in_dim = x.len();
@@ -210,7 +210,7 @@ pub fn approximate_gradient_fd<'a, T>(
     h: T,
 ) -> DVector<T>
 where
-    T: RealField,
+    T: Real,
 {
     let x = x.into();
     let mut df = DVector::zeros(x.len());
@@ -231,7 +231,7 @@ pub fn approximate_gradient_fd_into<'a, T>(
     x: impl Into<DVectorSliceMut<'a, T>>,
     h: T,
 ) where
-    T: RealField,
+    T: Real,
 {
     approximate_gradient_fd_into_(DVectorSliceMut::from(&mut df), f, x.into(), h);
 }
@@ -243,7 +243,7 @@ fn approximate_gradient_fd_into_<T>(
     mut x: DVectorSliceMut<T>,
     h: T,
 ) where
-    T: RealField,
+    T: Real,
 {
     let n = x.len();
     for i in 0..n {
@@ -272,7 +272,7 @@ pub fn approximate_jacobian_fd<'a, T>(
     h: T,
 ) -> DMatrix<T>
 where
-    T: RealField,
+    T: Real,
 {
     let x = x.into();
     let n = x.len();
@@ -291,7 +291,7 @@ pub fn approximate_jacobian_fd_into<'a, T>(
     x: impl Into<DVectorSliceMut<'a, T>>,
     h: T,
 ) where
-    T: RealField,
+    T: Real,
 {
     approximate_jacobian_fd_into_(jacobian.into(), f, x.into(), h);
 }
@@ -303,7 +303,7 @@ fn approximate_jacobian_fd_into_<T>(
     mut x: DVectorSliceMut<T>,
     h: T,
 ) where
-    T: RealField,
+    T: Real,
 {
     let m = j.nrows();
     let n = x.len();

--- a/fenris-optimize/src/newton.rs
+++ b/fenris-optimize/src/newton.rs
@@ -1,7 +1,8 @@
 use crate::calculus::{DifferentiableVectorFunction, VectorFunction};
+use fenris_traits::Real;
 use itertools::iterate;
 use log::debug;
-use nalgebra::{DVector, DVectorSlice, DVectorSliceMut, RealField, Scalar};
+use nalgebra::{DVector, DVectorSlice, DVectorSliceMut, Scalar};
 use numeric_literals::replace_float_literals;
 use std::error::Error;
 use std::fmt;
@@ -65,7 +66,7 @@ pub fn newton<'a, T, F>(
     settings: NewtonSettings<T>,
 ) -> Result<usize, NewtonError>
 where
-    T: RealField,
+    T: Real,
     F: DifferentiableVectorFunction<T>,
 {
     newton_line_search(function, x, f, dx, settings, &mut NoLineSearch {})
@@ -82,7 +83,7 @@ pub fn newton_line_search<'a, T, F>(
     line_search: &mut impl LineSearch<T, F>,
 ) -> Result<usize, NewtonError>
 where
-    T: RealField,
+    T: Real,
     F: DifferentiableVectorFunction<T>,
 {
     let mut x = x.into();
@@ -146,7 +147,7 @@ pub struct NoLineSearch;
 
 impl<T, F> LineSearch<T, F> for NoLineSearch
 where
-    T: RealField,
+    T: Real,
     F: VectorFunction<T>,
 {
     #[replace_float_literals(T::from_f64(literal).unwrap())]
@@ -172,7 +173,7 @@ pub struct BacktrackingLineSearch;
 
 impl<T, F> LineSearch<T, F> for BacktrackingLineSearch
 where
-    T: RealField,
+    T: Real,
     F: VectorFunction<T>,
 {
     #[replace_float_literals(T::from_f64(literal).unwrap())]

--- a/fenris-quadrature/Cargo.toml
+++ b/fenris-quadrature/Cargo.toml
@@ -15,7 +15,7 @@ embed-doc-image = { version="0.1.4", optional = true }
 
 [dev-dependencies]
 matrixcompare = "0.3.0"
-nalgebra = "0.28"
+nalgebra = "0.31"
 
 [build-dependencies]
 polyquad-parse = { path = "../polyquad-parse", version = "0.1" }

--- a/fenris-solid/src/gravity_source.rs
+++ b/fenris-solid/src/gravity_source.rs
@@ -1,8 +1,8 @@
 use fenris::allocators::DimAllocator;
 use fenris::assembly::local::{Density, SourceFunction};
 use fenris::assembly::operators::Operator;
-use fenris::nalgebra::{DefaultAllocator, OPoint, OVector, RealField, Scalar};
-use fenris::SmallDim;
+use fenris::nalgebra::{DefaultAllocator, OPoint, OVector, Scalar};
+use fenris::{Real, SmallDim};
 
 /// A source for the gravitational force.
 ///
@@ -44,7 +44,7 @@ where
 
 impl<T, D> Operator<T, D> for GravitySource<T, D>
 where
-    T: RealField,
+    T: Real,
     D: SmallDim,
     DefaultAllocator: DimAllocator<T, D>,
 {
@@ -56,7 +56,7 @@ where
 
 impl<T, D> SourceFunction<T, D> for GravitySource<T, D>
 where
-    T: RealField,
+    T: Real,
     D: SmallDim,
     DefaultAllocator: DimAllocator<T, D>,
 {

--- a/fenris-solid/src/lib.rs
+++ b/fenris-solid/src/lib.rs
@@ -1,8 +1,8 @@
 //! Solid mechanics functionality for `fenris`.
 use fenris::allocators::DimAllocator;
 use fenris::assembly::operators::{EllipticContraction, EllipticEnergy, EllipticOperator, Operator};
-use fenris::nalgebra::{DMatrixSliceMut, DVectorSlice, DefaultAllocator, DimName, OMatrix, OVector, RealField};
-use fenris::{SmallDim, Symmetry};
+use fenris::nalgebra::{DMatrixSliceMut, DVectorSlice, DefaultAllocator, DimName, OMatrix, OVector};
+use fenris::{Real, SmallDim, Symmetry};
 use std::cmp::min;
 
 pub mod materials;
@@ -12,7 +12,7 @@ pub use gravity_source::GravitySource;
 
 pub trait HyperelasticMaterial<T, GeometryDim>
 where
-    T: RealField,
+    T: Real,
     GeometryDim: DimName,
     DefaultAllocator: DimAllocator<T, GeometryDim>,
 {
@@ -143,7 +143,7 @@ pub fn compute_batch_contraction<T, GeometryDim>(
     b: DVectorSlice<T>,
     mut contraction: impl FnMut(&OVector<T, GeometryDim>, &OVector<T, GeometryDim>) -> OMatrix<T, GeometryDim, GeometryDim>,
 ) where
-    T: RealField,
+    T: Real,
     GeometryDim: DimName,
     DefaultAllocator: DimAllocator<T, GeometryDim>,
 {
@@ -209,7 +209,7 @@ impl<'a, Material> MaterialEllipticOperator<'a, Material> {
 
 impl<'a, T, GeometryDim, Material> Operator<T, GeometryDim> for MaterialEllipticOperator<'a, Material>
 where
-    T: RealField,
+    T: Real,
     GeometryDim: SmallDim,
     Material: HyperelasticMaterial<T, GeometryDim>,
     DefaultAllocator: DimAllocator<T, GeometryDim>,
@@ -220,7 +220,7 @@ where
 
 impl<'a, T, GeometryDim, Material> EllipticEnergy<T, GeometryDim> for MaterialEllipticOperator<'a, Material>
 where
-    T: RealField,
+    T: Real,
     GeometryDim: SmallDim,
     Material: HyperelasticMaterial<T, GeometryDim>,
     DefaultAllocator: DimAllocator<T, GeometryDim>,
@@ -233,7 +233,7 @@ where
 
 impl<'a, T, GeometryDim, Material> EllipticOperator<T, GeometryDim> for MaterialEllipticOperator<'a, Material>
 where
-    T: RealField,
+    T: Real,
     GeometryDim: SmallDim,
     Material: HyperelasticMaterial<T, GeometryDim>,
     DefaultAllocator: DimAllocator<T, GeometryDim>,
@@ -251,7 +251,7 @@ where
 
 impl<'a, T, GeometryDim, Material> EllipticContraction<T, GeometryDim> for MaterialEllipticOperator<'a, Material>
 where
-    T: RealField,
+    T: Real,
     GeometryDim: SmallDim,
     Material: HyperelasticMaterial<T, GeometryDim>,
     DefaultAllocator: DimAllocator<T, GeometryDim>,

--- a/fenris-solid/src/lib.rs
+++ b/fenris-solid/src/lib.rs
@@ -176,7 +176,7 @@ pub fn compute_batch_contraction<T, GeometryDim>(
             let mut c_IJ = output.generic_slice_mut((d * I, d * J), d_times_d);
             let contraction = contraction(&a_I, &b_J);
             // c_IJ += contraction * alpha
-            c_IJ.zip_apply(&contraction, |c: T, y: T| c + alpha * y);
+            c_IJ.zip_apply(&contraction, |c, y| *c += alpha * y);
         }
     }
 }

--- a/fenris-solid/src/materials.rs
+++ b/fenris-solid/src/materials.rs
@@ -1,7 +1,7 @@
 use crate::{compute_batch_contraction, HyperelasticMaterial};
 use fenris::allocators::DimAllocator;
-use fenris::nalgebra::{DMatrixSliceMut, DVectorSlice, DefaultAllocator, DimName, OMatrix, OVector, RealField};
-use fenris::SmallDim;
+use fenris::nalgebra::{DMatrixSliceMut, DVectorSlice, DefaultAllocator, DimName, OMatrix, OVector};
+use fenris::{Real, SmallDim};
 use numeric_literals::replace_float_literals;
 use serde::{Deserialize, Serialize};
 
@@ -13,7 +13,7 @@ pub struct LameParameters<T> {
 
 impl<T> Default for LameParameters<T>
 where
-    T: RealField,
+    T: Real,
 {
     #[replace_float_literals(T::from_f64(literal).expect("literal must fit in T"))]
     fn default() -> Self {
@@ -30,7 +30,7 @@ pub struct YoungPoisson<T> {
 
 impl<T> From<YoungPoisson<T>> for LameParameters<T>
 where
-    T: RealField,
+    T: Real,
 {
     #[replace_float_literals(T::from_f64(literal).expect("literal must fit in T"))]
     fn from(params: YoungPoisson<T>) -> Self {
@@ -70,7 +70,7 @@ pub struct LinearElasticMaterial;
 #[allow(non_snake_case)]
 fn infinitesimal_strain_tensor<T, D>(deformation_gradient: &OMatrix<T, D, D>) -> OMatrix<T, D, D>
 where
-    T: RealField,
+    T: Real,
     D: DimName,
     DefaultAllocator: DimAllocator<T, D>,
 {
@@ -82,7 +82,7 @@ where
 #[replace_float_literals(T::from_f64(literal).expect("literal must fit in T"))]
 impl<T, D> HyperelasticMaterial<T, D> for LinearElasticMaterial
 where
-    T: RealField,
+    T: Real,
     D: DimName,
     DefaultAllocator: DimAllocator<T, D>,
 {
@@ -235,7 +235,7 @@ pub struct NeoHookeanMaterial;
 #[replace_float_literals(T::from_f64(literal).expect("literal must fit in T"))]
 impl<T, D> HyperelasticMaterial<T, D> for NeoHookeanMaterial
 where
-    T: RealField,
+    T: Real,
     D: SmallDim,
     DefaultAllocator: DimAllocator<T, D>,
 {
@@ -375,7 +375,7 @@ pub struct StVKMaterial;
 #[replace_float_literals(T::from_f64(literal).expect("literal must fit in T"))]
 fn green_strain_tensor<T, D>(deformation_gradient: &OMatrix<T, D, D>) -> OMatrix<T, D, D>
 where
-    T: RealField,
+    T: Real,
     D: DimName,
     DefaultAllocator: DimAllocator<T, D>,
 {
@@ -388,7 +388,7 @@ where
 #[replace_float_literals(T::from_f64(literal).expect("literal must fit in T"))]
 impl<T, D> HyperelasticMaterial<T, D> for StVKMaterial
 where
-    T: RealField,
+    T: Real,
     D: DimName,
     DefaultAllocator: DimAllocator<T, D>,
 {

--- a/fenris-sparse/Cargo.toml
+++ b/fenris-sparse/Cargo.toml
@@ -9,8 +9,8 @@ description = "Sparse matrix functionality for fenris"
 
 [dependencies]
 fenris-traits = { version = "0.0.1", path = "../fenris-traits" }
-nalgebra = "0.28"
-nalgebra-sparse = "0.4"
+nalgebra = "0.31"
+nalgebra-sparse = "0.7"
 rayon = "1.3"
 num = "0.4"
 fenris-paradis = { version = "0.0.1", path = "../fenris-paradis" }

--- a/fenris-sparse/Cargo.toml
+++ b/fenris-sparse/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/InteractiveComputerGraphics/fenris"
 description = "Sparse matrix functionality for fenris"
 
 [dependencies]
+fenris-traits = { version = "0.0.1", path = "../fenris-traits" }
 nalgebra = "0.28"
 nalgebra-sparse = "0.4"
 rayon = "1.3"

--- a/fenris-sparse/src/cg.rs
+++ b/fenris-sparse/src/cg.rs
@@ -1,10 +1,9 @@
 use core::fmt;
+use fenris_traits::Real;
 use nalgebra::base::constraint::AreMultipliable;
 use nalgebra::constraint::{DimEq, ShapeConstraint};
 use nalgebra::storage::Storage;
-use nalgebra::{
-    ClosedAdd, ClosedMul, DVector, DVectorSlice, DVectorSliceMut, Dim, Dynamic, Matrix, RealField, Scalar, U1,
-};
+use nalgebra::{ClosedAdd, ClosedMul, DVector, DVectorSlice, DVectorSliceMut, Dim, Dynamic, Matrix, Scalar, U1};
 use nalgebra_sparse::ops::serial::spmm_csr_dense;
 use nalgebra_sparse::ops::Op;
 use nalgebra_sparse::CsrMatrix;
@@ -107,7 +106,7 @@ impl Default for RelativeResidualCriterion<f32> {
 
 impl<T> CgStoppingCriterion<T> for RelativeResidualCriterion<T>
 where
-    T: RealField,
+    T: Real,
 {
     fn has_converged(
         &self,
@@ -357,7 +356,7 @@ pub struct CgOutput<T> {
 
 impl<'a, T, A, P, Criterion> ConjugateGradient<'a, T, A, P, Criterion>
 where
-    T: RealField,
+    T: Real,
     A: LinearOperator<T>,
     P: LinearOperator<T>,
     Criterion: CgStoppingCriterion<T>,

--- a/fenris-sparse/src/sparse.rs
+++ b/fenris-sparse/src/sparse.rs
@@ -280,7 +280,7 @@ unsafe impl<'a, T: 'a + Sync + Send> ParallelIndexedCollection<'a> for ParallelC
 
 // impl<T> CsrMatrix<T>
 // where
-//     T: RealField,
+//     T: Real,
 // {
 //     pub fn scale_rows<'a>(&mut self, diagonal_matrix: impl Into<DVectorSlice<'a, T>>) {
 //         let diag = diagonal_matrix.into();

--- a/fenris-traits/Cargo.toml
+++ b/fenris-traits/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "fenris-traits"
+version = "0.0.1"
+authors = ["Andreas Longva <longva@cs.rwth-aachen.de>"]
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/InteractiveComputerGraphics/fenris"
+description = "Core traits used by fenris"
+edition = "2021"
+
+[dependencies]
+nalgebra = { version="0.28.0", default-features = false }

--- a/fenris-traits/Cargo.toml
+++ b/fenris-traits/Cargo.toml
@@ -8,4 +8,4 @@ description = "Core traits used by fenris"
 edition = "2021"
 
 [dependencies]
-nalgebra = { version="0.28.0", default-features = false }
+nalgebra = { version="0.31.0", default-features = false }

--- a/fenris-traits/src/lib.rs
+++ b/fenris-traits/src/lib.rs
@@ -1,0 +1,7 @@
+use nalgebra::RealField;
+
+pub use nalgebra;
+
+pub trait Real: RealField + Copy {}
+
+impl<T: RealField + Copy> Real for T {}

--- a/src/assembly/buffers.rs
+++ b/src/assembly/buffers.rs
@@ -2,13 +2,11 @@ use crate::allocators::{BiDimAllocator, DimAllocator};
 use crate::assembly::global::gather_global_to_local;
 use crate::assembly::local::QuadratureTable;
 use crate::nalgebra::allocator::Allocator;
-use crate::nalgebra::{
-    DMatrix, DefaultAllocator, DimName, Dynamic, MatrixSlice, MatrixSliceMut, OPoint, RealField, Scalar,
-};
+use crate::nalgebra::{DMatrix, DefaultAllocator, DimName, Dynamic, MatrixSlice, MatrixSliceMut, OPoint, Scalar};
 use crate::quadrature::Quadrature;
 use crate::space::FiniteElementSpace;
 use crate::util::compute_interpolation;
-use crate::SmallDim;
+use crate::{Real, SmallDim};
 use itertools::izip;
 use nalgebra::{DVector, DVectorSlice, OMatrix, OVector};
 
@@ -19,7 +17,7 @@ pub struct BasisFunctionBuffer<T: Scalar> {
     element_basis_gradients: DMatrix<T>,
 }
 
-impl<T: RealField> Default for BasisFunctionBuffer<T> {
+impl<T: Real> Default for BasisFunctionBuffer<T> {
     fn default() -> Self {
         Self {
             element_nodes: Vec::new(),
@@ -29,7 +27,7 @@ impl<T: RealField> Default for BasisFunctionBuffer<T> {
     }
 }
 
-impl<T: RealField> BasisFunctionBuffer<T> {
+impl<T: Real> BasisFunctionBuffer<T> {
     pub fn resize(&mut self, node_count: usize, reference_dim: usize) {
         self.element_nodes.resize(node_count, usize::MAX);
         self.element_basis_values.resize(node_count, T::zero());
@@ -146,7 +144,7 @@ where
 
 impl<T, GeometryDim, Data> QuadratureBuffer<T, GeometryDim, Data>
 where
-    T: RealField,
+    T: Real,
     GeometryDim: SmallDim,
     Data: Default + Clone,
     DefaultAllocator: DimAllocator<T, GeometryDim>,
@@ -224,7 +222,7 @@ pub struct InterpolationBuffer<T: Scalar> {
     u_local: DVector<T>,
 }
 
-impl<T: RealField> Default for InterpolationBuffer<T> {
+impl<T: Real> Default for InterpolationBuffer<T> {
     fn default() -> Self {
         Self {
             basis_buffer: Default::default(),
@@ -245,7 +243,7 @@ where
     element_index: usize,
 }
 
-impl<T: RealField> InterpolationBuffer<T> {
+impl<T: Real> InterpolationBuffer<T> {
     pub fn prepare_element_in_space<'a, Space>(
         &'a mut self,
         element_index: usize,
@@ -283,7 +281,7 @@ impl<T: RealField> InterpolationBuffer<T> {
 
 impl<'a, T, Space> InterpolationElementBuffer<'a, T, Space>
 where
-    T: RealField,
+    T: Real,
     Space: FiniteElementSpace<T>,
     DefaultAllocator: BiDimAllocator<T, Space::GeometryDim, Space::ReferenceDim>,
 {

--- a/src/assembly/local.rs
+++ b/src/assembly/local.rs
@@ -1,8 +1,9 @@
 use crate::connectivity::Connectivity;
 use crate::mesh::Mesh;
 use crate::nalgebra::allocator::Allocator;
+use crate::nalgebra::{DMatrix, DVector, DVectorSliceMut};
 use crate::nalgebra::{DMatrixSliceMut, DefaultAllocator, DimName, Scalar};
-use crate::nalgebra::{DVector, DVectorSliceMut};
+use crate::Real;
 
 mod elliptic;
 mod mass;
@@ -11,7 +12,6 @@ mod source;
 
 pub use elliptic::*;
 pub use mass::*;
-use nalgebra::{DMatrix, RealField};
 pub use quadrature_table::*;
 pub use source::*;
 
@@ -79,7 +79,7 @@ pub trait ElementMatrixAssembler<T: Scalar>: ElementConnectivityAssembler {
 
     fn assemble_element_matrix(&self, element_index: usize) -> eyre::Result<DMatrix<T>>
     where
-        T: RealField,
+        T: Real,
     {
         let ndof = self.solution_dim() * self.element_node_count(element_index);
         let mut output = DMatrix::zeros(ndof, ndof);
@@ -107,7 +107,7 @@ pub trait ElementVectorAssembler<T: Scalar>: ElementConnectivityAssembler {
 
     fn assemble_element_vector(&self, element_index: usize) -> eyre::Result<DVector<T>>
     where
-        T: RealField,
+        T: Real,
     {
         let ndof = self.solution_dim() * self.element_node_count(element_index);
         let mut output = DVector::zeros(ndof);

--- a/src/assembly/local/elliptic.rs
+++ b/src/assembly/local/elliptic.rs
@@ -11,11 +11,12 @@ use crate::element::VolumetricFiniteElement;
 use crate::nalgebra::allocator::Allocator;
 use crate::nalgebra::{
     DMatrixSliceMut, DVector, DVectorSlice, DVectorSliceMut, DefaultAllocator, Dim, DimName, Dynamic, MatrixSlice,
-    MatrixSliceMut, MatrixSliceMutMN, OMatrix, OPoint, RealField, Scalar, U1,
+    MatrixSliceMut, MatrixSliceMutMN, OMatrix, OPoint, Scalar, U1,
 };
 use crate::space::{ElementInSpace, VolumetricFiniteElementSpace};
 use crate::util::{clone_upper_to_lower, reshape_to_slice};
 use crate::workspace::with_thread_local_workspace;
+use crate::Real;
 use crate::Symmetry;
 use eyre::eyre;
 use itertools::izip;
@@ -28,7 +29,7 @@ pub(crate) fn compute_volume_u_grad<'a, T, GeometryDim, SolutionDim>(
     u: impl Into<MatrixSlice<'a, T, SolutionDim, Dynamic>>,
 ) -> OMatrix<T, GeometryDim, SolutionDim>
 where
-    T: RealField,
+    T: Real,
     SolutionDim: DimName,
     GeometryDim: DimName,
     DefaultAllocator: BiDimAllocator<T, SolutionDim, GeometryDim>,
@@ -200,7 +201,7 @@ where
 
 impl<T, GeometryDim, Data> Default for EllipticAssemblerWorkspace<T, GeometryDim, Data>
 where
-    T: RealField,
+    T: Real,
     GeometryDim: DimName,
     DefaultAllocator: Allocator<T, GeometryDim>,
 {
@@ -217,7 +218,7 @@ define_thread_local_workspace!(WORKSPACE);
 
 impl<'a, T, Space, Op, QTable> ElementScalarAssembler<T> for ElementEllipticAssembler<'a, T, Space, Op, QTable>
 where
-    T: RealField,
+    T: Real,
     Space: VolumetricFiniteElementSpace<T>,
     Op: EllipticEnergy<T, Space::ReferenceDim>,
     QTable: QuadratureTable<T, Space::ReferenceDim, Data = Op::Parameters> + ?Sized,
@@ -256,7 +257,7 @@ where
 
 impl<'a, T, Space, Op, QTable> ElementVectorAssembler<T> for ElementEllipticAssembler<'a, T, Space, Op, QTable>
 where
-    T: RealField,
+    T: Real,
     Space: VolumetricFiniteElementSpace<T>,
     Op: EllipticOperator<T, Space::ReferenceDim>,
     QTable: QuadratureTable<T, Space::ReferenceDim, Data = Op::Parameters> + ?Sized,
@@ -298,7 +299,7 @@ where
 
 impl<'a, T, Space, Op, QTable> ElementMatrixAssembler<T> for ElementEllipticAssembler<'a, T, Space, Op, QTable>
 where
-    T: RealField,
+    T: Real,
     Space: VolumetricFiniteElementSpace<T>,
     Op: EllipticContraction<T, Space::ReferenceDim>,
     QTable: QuadratureTable<T, Space::ReferenceDim, Data = Op::Parameters> + ?Sized,
@@ -369,7 +370,7 @@ pub fn assemble_element_elliptic_matrix<T, Element, Contraction>(
     basis_gradients_buffer: MatrixSliceMutMN<T, Element::ReferenceDim, Dynamic>,
 ) -> eyre::Result<()>
 where
-    T: RealField,
+    T: Real,
     // We only support volumetric elements atm
     Element: VolumetricFiniteElement<T>,
     Contraction: EllipticContraction<T, Element::GeometryDim>,
@@ -465,7 +466,7 @@ pub fn assemble_element_elliptic_vector<T, Element, Operator>(
     basis_gradients_buffer: MatrixSliceMutMN<T, Element::ReferenceDim, Dynamic>,
 ) -> eyre::Result<()>
 where
-    T: RealField,
+    T: Real,
     // We only support volumetric elements atm
     Element: VolumetricFiniteElement<T>,
     Operator: EllipticOperator<T, Element::GeometryDim>,
@@ -559,7 +560,7 @@ pub fn compute_element_elliptic_energy<T, Element, Operator>(
     basis_gradients_buffer: MatrixSliceMutMN<T, Element::ReferenceDim, Dynamic>,
 ) -> eyre::Result<T>
 where
-    T: RealField,
+    T: Real,
     // We only support volumetric elements atm
     Element: VolumetricFiniteElement<T>,
     Operator: EllipticEnergy<T, Element::GeometryDim>,

--- a/src/assembly/local/mass.rs
+++ b/src/assembly/local/mass.rs
@@ -7,8 +7,9 @@ use crate::nalgebra::{DMatrixSliceMut, DefaultAllocator, DimName, OPoint};
 use crate::space::{ElementInSpace, FiniteElementConnectivity, VolumetricFiniteElementSpace};
 use crate::util::clone_upper_to_lower;
 use crate::workspace::with_thread_local_workspace;
+use crate::Real;
 use itertools::izip;
-use nalgebra::{RealField, Scalar};
+use nalgebra::Scalar;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 
@@ -31,7 +32,7 @@ impl<T> Density<T> {
     }
 }
 
-impl<T: RealField> Default for Density<T> {
+impl<T: Real> Default for Density<T> {
     fn default() -> Self {
         Density(T::zero())
     }
@@ -116,7 +117,7 @@ where
     basis_buffer: BasisFunctionBuffer<T>,
 }
 
-impl<T: RealField, D: DimName> Default for MassAssemblerWorkspace<T, D>
+impl<T: Real, D: DimName> Default for MassAssemblerWorkspace<T, D>
 where
     DefaultAllocator: DimAllocator<T, D>,
 {
@@ -130,7 +131,7 @@ where
 
 impl<'a, T, Space, QTable> ElementMatrixAssembler<T> for ElementMassAssembler<'a, Space, QTable>
 where
-    T: RealField,
+    T: Real,
     Space: VolumetricFiniteElementSpace<T>,
     QTable: QuadratureTable<T, Space::GeometryDim, Data = Density<T>>,
     DefaultAllocator: DimAllocator<T, Space::GeometryDim>,
@@ -198,7 +199,7 @@ pub fn assemble_element_mass_matrix<'a, T, Element>(
     basis_values_buffer: &mut [T],
 ) -> eyre::Result<()>
 where
-    T: RealField,
+    T: Real,
     // We only support volumetric elements atm
     Element: VolumetricFiniteElement<T>,
     DefaultAllocator: DimAllocator<T, Element::GeometryDim>,
@@ -225,7 +226,7 @@ fn assemble_element_mass_matrix_<T, Element>(
     basis_values_buffer: &mut [T],
 ) -> eyre::Result<()>
 where
-    T: RealField,
+    T: Real,
     // We only support volumetric elements atm
     Element: VolumetricFiniteElement<T>,
     DefaultAllocator: DimAllocator<T, Element::GeometryDim>,

--- a/src/assembly/local/source.rs
+++ b/src/assembly/local/source.rs
@@ -5,12 +5,11 @@ use crate::assembly::operators::Operator;
 use crate::define_thread_local_workspace;
 use crate::element::{ReferenceFiniteElement, VolumetricFiniteElement};
 use crate::nalgebra::{
-    DVectorSliceMut, DefaultAllocator, DimName, Dynamic, MatrixSlice, MatrixSliceMutMN, OPoint, OVector, RealField,
-    Scalar, U1,
+    DVectorSliceMut, DefaultAllocator, DimName, Dynamic, MatrixSlice, MatrixSliceMutMN, OPoint, OVector, Scalar, U1,
 };
 use crate::space::{ElementInSpace, VolumetricFiniteElementSpace};
 use crate::workspace::with_thread_local_workspace;
-use crate::SmallDim;
+use crate::{Real, SmallDim};
 use itertools::izip;
 use std::marker::PhantomData;
 
@@ -146,7 +145,7 @@ where
 
 impl<T, D, Data> Default for SourceTermWorkspace<T, D, Data>
 where
-    T: RealField,
+    T: Real,
     D: SmallDim,
     DefaultAllocator: DimAllocator<T, D>,
 {
@@ -160,7 +159,7 @@ where
 
 impl<'a, T, Space, Source, QTable> ElementVectorAssembler<T> for ElementSourceAssembler<'a, T, Space, Source, QTable>
 where
-    T: RealField,
+    T: Real,
     Space: VolumetricFiniteElementSpace<T>,
     Source: SourceFunction<T, Space::ReferenceDim>,
     QTable: QuadratureTable<T, Space::ReferenceDim, Data = Source::Parameters>,
@@ -225,7 +224,7 @@ pub fn assemble_element_source_vector<T, Element, Source>(
     quadrature_data: &[Source::Parameters],
     basis_values_buffer: &mut [T],
 ) where
-    T: RealField,
+    T: Real,
     // We only support volumetric elements atm
     Element: VolumetricFiniteElement<T>,
     Source: SourceFunction<T, Element::GeometryDim>,

--- a/src/assembly/operators.rs
+++ b/src/assembly/operators.rs
@@ -1,7 +1,7 @@
 use crate::allocators::BiDimAllocator;
 use crate::nalgebra::allocator::Allocator;
-use crate::nalgebra::{DMatrixSliceMut, DVectorSlice, DefaultAllocator, DimName, OMatrix, OVector, RealField, Scalar};
-use crate::{SmallDim, Symmetry};
+use crate::nalgebra::{DMatrixSliceMut, DVectorSlice, DefaultAllocator, DimName, OMatrix, OVector, Scalar};
+use crate::{Real, SmallDim, Symmetry};
 
 mod laplace;
 pub use laplace::*;
@@ -47,7 +47,7 @@ where
 /// TODO: Maybe return results in impls...?
 pub trait EllipticContraction<T, GeometryDim>: Operator<T, GeometryDim>
 where
-    T: RealField,
+    T: Real,
     GeometryDim: SmallDim,
     DefaultAllocator: BiDimAllocator<T, GeometryDim, Self::SolutionDim>,
 {
@@ -210,7 +210,7 @@ where
 /// e.g. $\psi = \psi(x, \nabla u)$.
 pub trait EllipticEnergy<T, GeometryDim>: Operator<T, GeometryDim>
 where
-    T: RealField,
+    T: Real,
     GeometryDim: SmallDim,
     DefaultAllocator: BiDimAllocator<T, GeometryDim, Self::SolutionDim>,
 {

--- a/src/assembly/operators/laplace.rs
+++ b/src/assembly/operators/laplace.rs
@@ -1,7 +1,7 @@
 use crate::allocators::{BiDimAllocator, DimAllocator};
 use crate::assembly::operators::{EllipticContraction, EllipticEnergy, EllipticOperator, Operator};
-use crate::nalgebra::{DefaultAllocator, OMatrix, OVector, RealField, U1};
-use crate::{SmallDim, Symmetry};
+use crate::nalgebra::{DefaultAllocator, OMatrix, OVector, U1};
+use crate::{Real, SmallDim, Symmetry};
 use numeric_literals::replace_float_literals;
 
 /// The Laplace operator $\Delta = \nabla^2$.
@@ -25,7 +25,7 @@ impl<T, GeometryDim> Operator<T, GeometryDim> for LaplaceOperator {
 
 impl<T, D> EllipticEnergy<T, D> for LaplaceOperator
 where
-    T: RealField,
+    T: Real,
     D: SmallDim,
     DefaultAllocator: BiDimAllocator<T, D, Self::SolutionDim>,
 {
@@ -37,7 +37,7 @@ where
 
 impl<T, D> EllipticOperator<T, D> for LaplaceOperator
 where
-    T: RealField,
+    T: Real,
     D: SmallDim,
     DefaultAllocator: BiDimAllocator<T, D, Self::SolutionDim>,
 {
@@ -52,7 +52,7 @@ where
 
 impl<T, D> EllipticContraction<T, D> for LaplaceOperator
 where
-    T: RealField,
+    T: Real,
     D: SmallDim,
     DefaultAllocator: DimAllocator<T, D>,
 {

--- a/src/connectivity.rs
+++ b/src/connectivity.rs
@@ -1,7 +1,8 @@
 use crate::geometry::{Hexahedron, LineSegment2d, Quad2d, Tetrahedron, Triangle, Triangle2d, Triangle3d};
+use crate::Real;
 use itertools::izip;
 use nalgebra::allocator::Allocator;
-use nalgebra::{DefaultAllocator, DimName, OPoint, Point2, Point3, RealField, Scalar, U2, U3};
+use nalgebra::{DefaultAllocator, DimName, OPoint, Point2, Point3, Scalar, U2, U3};
 use serde::{Deserialize, Serialize};
 use std::ops::{Deref, DerefMut};
 
@@ -554,7 +555,7 @@ impl ConnectivityMut for Tet4Connectivity {
 
 impl<T> CellConnectivity<T, U3> for Tet4Connectivity
 where
-    T: RealField,
+    T: Real,
 {
     type Cell = Tetrahedron<T>;
 
@@ -645,7 +646,7 @@ impl ConnectivityMut for Hex8Connectivity {
 
 impl<T> CellConnectivity<T, U3> for Hex8Connectivity
 where
-    T: RealField,
+    T: Real,
 {
     type Cell = Hexahedron<T>;
 
@@ -707,7 +708,7 @@ impl ConnectivityMut for Hex27Connectivity {
 
 impl<T> CellConnectivity<T, U3> for Hex27Connectivity
 where
-    T: RealField,
+    T: Real,
 {
     type Cell = Hexahedron<T>;
 
@@ -773,7 +774,7 @@ impl ConnectivityMut for Hex20Connectivity {
 
 impl<T> CellConnectivity<T, U3> for Hex20Connectivity
 where
-    T: RealField,
+    T: Real,
 {
     type Cell = Hexahedron<T>;
 
@@ -948,7 +949,7 @@ impl ConnectivityMut for Tet10Connectivity {
 
 impl<T> CellConnectivity<T, U3> for Tet10Connectivity
 where
-    T: RealField,
+    T: Real,
 {
     type Cell = Tetrahedron<T>;
 
@@ -998,7 +999,7 @@ impl ConnectivityMut for Tet20Connectivity {
 
 impl<T> CellConnectivity<T, U3> for Tet20Connectivity
 where
-    T: RealField,
+    T: Real,
 {
     type Cell = Tetrahedron<T>;
 

--- a/src/element.rs
+++ b/src/element.rs
@@ -1,12 +1,12 @@
 use crate::allocators::{BiDimAllocator, DimAllocator};
 use crate::connectivity::Connectivity;
 use crate::nalgebra::MatrixSliceMut;
-use crate::SmallDim;
+use crate::{Real, SmallDim};
 use fenris_optimize::newton::NewtonSettings;
 use nalgebra::allocator::Allocator;
 use nalgebra::OPoint;
 use nalgebra::{DVectorSlice, DVectorSliceMut, DimName, Dynamic};
-use nalgebra::{DefaultAllocator, DimMin, OMatrix, OVector, RealField, Scalar, U1};
+use nalgebra::{DefaultAllocator, DimMin, OMatrix, OVector, Scalar, U1};
 use num::Zero;
 use numeric_literals::replace_float_literals;
 use std::error::Error;
@@ -244,7 +244,7 @@ pub type ElementGeometryDim<T, Element> = <Element as FiniteElement<T>>::Geometr
 #[inline(always)]
 fn phi_linear_1d<T>(alpha: T, xi: T) -> T
 where
-    T: RealField,
+    T: Real,
 {
     (1.0 + alpha * xi) / 2.0
 }
@@ -256,7 +256,7 @@ where
 #[inline(always)]
 fn phi_linear_1d_grad<T>(alpha: T) -> T
 where
-    T: RealField,
+    T: Real,
 {
     alpha / 2.0
 }
@@ -270,7 +270,7 @@ where
 #[inline(always)]
 fn phi_quadratic_1d<T>(alpha: T, xi: T) -> T
 where
-    T: RealField,
+    T: Real,
 {
     // The compiler should hopefully be able to use constant propagation to
     // precompute all expressions involving constants and alpha
@@ -288,7 +288,7 @@ where
 #[inline(always)]
 fn phi_quadratic_1d_grad<T>(alpha: T, xi: T) -> T
 where
-    T: RealField,
+    T: Real,
 {
     // The compiler should hopefully be able to use constant propagation to
     // precompute all expressions involving constants and alpha
@@ -304,7 +304,7 @@ pub fn map_physical_coordinates<T, Element, GeometryDim>(
     x: &OPoint<T, GeometryDim>,
 ) -> Result<OPoint<T, GeometryDim>, Box<dyn Error>>
 where
-    T: RealField,
+    T: Real,
     Element: FiniteElement<T, GeometryDim = GeometryDim, ReferenceDim = GeometryDim>,
     GeometryDim: DimName + DimMin<GeometryDim, Output = GeometryDim>,
     DefaultAllocator: DimAllocator<T, GeometryDim>,
@@ -397,7 +397,7 @@ pub fn project_physical_coordinates<T, Element>(
     x: &OPoint<T, Element::GeometryDim>,
 ) -> Result<OPoint<T, Element::ReferenceDim>, Box<dyn Error>>
 where
-    T: RealField,
+    T: Real,
     Element: FiniteElement<T>,
     Element::ReferenceDim: DimName + DimMin<Element::ReferenceDim, Output = Element::ReferenceDim>,
     DefaultAllocator: BiDimAllocator<T, Element::GeometryDim, Element::ReferenceDim>,

--- a/src/element/hexahedron.rs
+++ b/src/element/hexahedron.rs
@@ -6,11 +6,12 @@ use numeric_literals::replace_float_literals;
 use crate::connectivity::{Hex20Connectivity, Hex27Connectivity, Hex8Connectivity};
 use crate::element;
 use crate::element::{ElementConnectivity, FiniteElement, FixedNodesReferenceFiniteElement};
-use crate::nalgebra::{distance, Matrix3, OMatrix, OPoint, Point3, RealField, Scalar, Vector3, U1, U20, U27, U3, U8};
+use crate::nalgebra::{distance, Matrix3, OMatrix, OPoint, Point3, Scalar, Vector3, U1, U20, U27, U3, U8};
+use crate::Real;
 
 impl<T> ElementConnectivity<T> for Hex8Connectivity
 where
-    T: RealField,
+    T: Real,
 {
     type Element = Hex8Element<T>;
     type GeometryDim = U3;
@@ -32,7 +33,7 @@ where
 
 impl<T> FixedNodesReferenceFiniteElement<T> for Hex8Element<T>
 where
-    T: RealField,
+    T: Real,
 {
     type ReferenceDim = U3;
     type NodalDim = U8;
@@ -84,7 +85,7 @@ where
 
 impl<T> FiniteElement<T> for Hex8Element<T>
 where
-    T: RealField,
+    T: Real,
 {
     type GeometryDim = U3;
 
@@ -135,7 +136,7 @@ where
 
 impl<T> Hex8Element<T>
 where
-    T: RealField,
+    T: Real,
 {
     #[replace_float_literals(T::from_f64(literal).expect("Literal must fit in T"))]
     pub fn reference() -> Self {
@@ -172,7 +173,7 @@ impl<T: Scalar + Copy> Hex27Element<T> {
     }
 }
 
-impl<T: RealField> Hex27Element<T> {
+impl<T: Real> Hex27Element<T> {
     #[replace_float_literals(T::from_f64(literal).expect("Literal must fit in T"))]
     pub fn reference() -> Self {
         Self::from_vertices([
@@ -212,7 +213,7 @@ impl<T: RealField> Hex27Element<T> {
 
 impl<T> FixedNodesReferenceFiniteElement<T> for Hex27Element<T>
 where
-    T: RealField,
+    T: Real,
 {
     type ReferenceDim = U3;
     type NodalDim = U27;
@@ -316,7 +317,7 @@ where
 
 impl<T> FiniteElement<T> for Hex27Element<T>
 where
-    T: RealField,
+    T: Real,
 {
     type GeometryDim = U3;
 
@@ -335,7 +336,7 @@ where
 
 impl<T> ElementConnectivity<T> for Hex27Connectivity
 where
-    T: RealField,
+    T: Real,
 {
     type Element = Hex27Element<T>;
     type GeometryDim = U3;
@@ -372,7 +373,7 @@ impl<T: Scalar + Copy> Hex20Element<T> {
     }
 }
 
-impl<T: RealField> Hex20Element<T> {
+impl<T: Real> Hex20Element<T> {
     #[replace_float_literals(T::from_f64(literal).expect("Literal must fit in T"))]
     pub fn reference() -> Self {
         Self::from_vertices([
@@ -403,7 +404,7 @@ impl<T: RealField> Hex20Element<T> {
 
 impl<T> FixedNodesReferenceFiniteElement<T> for Hex20Element<T>
 where
-    T: RealField,
+    T: Real,
 {
     type ReferenceDim = U3;
     type NodalDim = U20;
@@ -544,7 +545,7 @@ where
 
 impl<T> FiniteElement<T> for Hex20Element<T>
 where
-    T: RealField,
+    T: Real,
 {
     type GeometryDim = U3;
 
@@ -563,7 +564,7 @@ where
 
 impl<T> ElementConnectivity<T> for Hex20Connectivity
 where
-    T: RealField,
+    T: Real,
 {
     type Element = Hex20Element<T>;
     type GeometryDim = U3;

--- a/src/element/quadrilateral.rs
+++ b/src/element/quadrilateral.rs
@@ -7,8 +7,9 @@ use crate::connectivity::{Quad4d2Connectivity, Quad9d2Connectivity};
 use crate::element::{ElementConnectivity, FiniteElement, FixedNodesReferenceFiniteElement};
 use crate::geometry::{ConcavePolygonError, ConvexPolygon, LineSegment2d, Quad2d};
 use crate::nalgebra::{
-    distance, Matrix1x4, Matrix2, Matrix2x4, OMatrix, OPoint, Point2, RealField, Scalar, Vector2, U1, U2, U4, U9,
+    distance, Matrix1x4, Matrix2, Matrix2x4, OMatrix, OPoint, Point2, Scalar, Vector2, U1, U2, U4, U9,
 };
+use crate::Real;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Quad4d2Element<T>
@@ -42,7 +43,7 @@ where
 
 impl<T> Quad4d2Element<T>
 where
-    T: RealField,
+    T: Real,
 {
     #[replace_float_literals(T::from_f64(literal).unwrap())]
     pub fn reference() -> Self {
@@ -57,7 +58,7 @@ where
 
 impl<T> TryFrom<Quad4d2Element<T>> for ConvexPolygon<T>
 where
-    T: RealField,
+    T: Real,
 {
     type Error = ConcavePolygonError;
 
@@ -68,7 +69,7 @@ where
 
 impl<T> FixedNodesReferenceFiniteElement<T> for Quad4d2Element<T>
 where
-    T: RealField,
+    T: Real,
 {
     type NodalDim = U4;
     type ReferenceDim = U2;
@@ -108,7 +109,7 @@ where
 
 impl<T> FiniteElement<T> for Quad4d2Element<T>
 where
-    T: RealField,
+    T: Real,
 {
     type GeometryDim = U2;
 
@@ -171,7 +172,7 @@ where
 
 impl<'a, T> From<&'a Quad4d2Element<T>> for Quad9d2Element<T>
 where
-    T: RealField,
+    T: Real,
 {
     fn from(quad4: &'a Quad4d2Element<T>) -> Self {
         let midpoint = |a: &Point2<_>, b: &Point2<_>| LineSegment2d::from_end_points(a.clone(), b.clone()).midpoint();
@@ -194,7 +195,7 @@ where
 
 impl<'a, T> From<Quad4d2Element<T>> for Quad9d2Element<T>
 where
-    T: RealField,
+    T: Real,
 {
     fn from(quad4: Quad4d2Element<T>) -> Self {
         Self::from(&quad4)
@@ -203,7 +204,7 @@ where
 
 impl<T> Quad9d2Element<T>
 where
-    T: RealField,
+    T: Real,
 {
     #[replace_float_literals(T::from_f64(literal).expect("Literal must fit in T"))]
     pub fn reference() -> Self {
@@ -225,7 +226,7 @@ where
 #[replace_float_literals(T::from_f64(literal).expect("Literal must fit in T"))]
 fn quad9_phi_1d<T>(alpha: T, xi: T) -> T
 where
-    T: RealField,
+    T: Real,
 {
     let alpha2 = alpha * alpha;
     let a = (3.0 / 2.0) * alpha2 - 1.0;
@@ -236,7 +237,7 @@ where
 
 impl<T> FixedNodesReferenceFiniteElement<T> for Quad9d2Element<T>
 where
-    T: RealField,
+    T: Real,
 {
     type ReferenceDim = U2;
     type NodalDim = U9;
@@ -307,7 +308,7 @@ where
 
 impl<T> FiniteElement<T> for Quad9d2Element<T>
 where
-    T: RealField,
+    T: Real,
 {
     type GeometryDim = U2;
 
@@ -329,7 +330,7 @@ where
 
 impl<T> TryFrom<Quad9d2Element<T>> for ConvexPolygon<T>
 where
-    T: RealField,
+    T: Real,
 {
     type Error = ConcavePolygonError;
 
@@ -340,7 +341,7 @@ where
 
 impl<T> ElementConnectivity<T> for Quad4d2Connectivity
 where
-    T: RealField,
+    T: Real,
 {
     type Element = Quad4d2Element<T>;
     type ReferenceDim = U2;
@@ -361,7 +362,7 @@ where
 
 impl<T> ElementConnectivity<T> for Quad9d2Connectivity
 where
-    T: RealField,
+    T: Real,
 {
     type Element = Quad9d2Element<T>;
     type ReferenceDim = U2;

--- a/src/element/segment.rs
+++ b/src/element/segment.rs
@@ -1,7 +1,8 @@
 use crate::connectivity::{Segment2d1Connectivity, Segment2d2Connectivity};
 use crate::element::{ElementConnectivity, FiniteElement, FixedNodesReferenceFiniteElement, SurfaceFiniteElement};
 use crate::geometry::LineSegment2d;
-use crate::nalgebra::{OMatrix, OPoint, Point1, Point2, RealField, Scalar, Vector2, U1, U2};
+use crate::nalgebra::{OMatrix, OPoint, Point1, Point2, Scalar, Vector2, U1, U2};
+use crate::Real;
 use nalgebra::{point, Vector1};
 use numeric_literals::replace_float_literals;
 
@@ -78,20 +79,20 @@ impl<'a, T: Scalar> From<&'a Segment2d2Element<T>> for LineSegment2d<T> {
 }
 
 #[replace_float_literals(T::from_f64(literal).expect("Literal must fit in T"))]
-fn segment2_basis<T: RealField>(xi: T) -> OMatrix<T, U1, U2> {
+fn segment2_basis<T: Real>(xi: T) -> OMatrix<T, U1, U2> {
     let phi_1 = (1.0 - xi) / 2.0;
     let phi_2 = (1.0 + xi) / 2.0;
     OMatrix::<_, U1, U2>::new(phi_1, phi_2)
 }
 
 #[replace_float_literals(T::from_f64(literal).expect("Literal must fit in T"))]
-fn segment2_gradients<T: RealField>() -> OMatrix<T, U1, U2> {
+fn segment2_gradients<T: Real>() -> OMatrix<T, U1, U2> {
     OMatrix::<_, U1, U2>::new(-0.5, 0.5)
 }
 
 impl<T> FixedNodesReferenceFiniteElement<T> for Segment2d1Element<T>
 where
-    T: RealField,
+    T: Real,
 {
     type NodalDim = U2;
     type ReferenceDim = U1;
@@ -109,7 +110,7 @@ where
 
 impl<T> FixedNodesReferenceFiniteElement<T> for Segment2d2Element<T>
 where
-    T: RealField,
+    T: Real,
 {
     type NodalDim = U2;
     type ReferenceDim = U1;
@@ -125,7 +126,7 @@ where
 
 impl<T> FiniteElement<T> for Segment2d1Element<T>
 where
-    T: RealField,
+    T: Real,
 {
     type GeometryDim = U1;
 
@@ -153,7 +154,7 @@ where
 
 impl<T> FiniteElement<T> for Segment2d2Element<T>
 where
-    T: RealField,
+    T: Real,
 {
     type GeometryDim = U2;
 
@@ -183,7 +184,7 @@ where
 
 impl<T> SurfaceFiniteElement<T> for Segment2d2Element<T>
 where
-    T: RealField,
+    T: Real,
 {
     fn normal(&self, _xi: &Point1<T>) -> Vector2<T> {
         self.to_line_segment().normal_dir().normalize()
@@ -192,7 +193,7 @@ where
 
 impl<T> ElementConnectivity<T> for Segment2d2Connectivity
 where
-    T: RealField,
+    T: Real,
 {
     type Element = Segment2d2Element<T>;
     type ReferenceDim = U1;
@@ -208,7 +209,7 @@ where
 
 impl<T> ElementConnectivity<T> for Segment2d1Connectivity
 where
-    T: RealField,
+    T: Real,
 {
     type Element = Segment2d1Element<T>;
     type GeometryDim = U1;

--- a/src/element/tetrahedron.rs
+++ b/src/element/tetrahedron.rs
@@ -3,13 +3,14 @@ use numeric_literals::replace_float_literals;
 use crate::connectivity::{Tet10Connectivity, Tet4Connectivity};
 use crate::element::{ElementConnectivity, FiniteElement, FixedNodesReferenceFiniteElement};
 use crate::nalgebra::{
-    distance, Matrix1x4, Matrix3, Matrix3x4, OMatrix, OPoint, Point3, RealField, Scalar, Vector3, U1, U10, U20, U3, U4,
+    distance, Matrix1x4, Matrix3, Matrix3x4, OMatrix, OPoint, Point3, Scalar, Vector3, U1, U10, U20, U3, U4,
 };
+use crate::Real;
 use itertools::Itertools;
 
 impl<T> ElementConnectivity<T> for Tet4Connectivity
 where
-    T: RealField,
+    T: Real,
 {
     type Element = Tet4Element<T>;
     type GeometryDim = U3;
@@ -29,7 +30,7 @@ where
 
 impl<T> ElementConnectivity<T> for Tet10Connectivity
 where
-    T: RealField,
+    T: Real,
 {
     type Element = Tet10Element<T>;
     type GeometryDim = U3;
@@ -84,7 +85,7 @@ where
 
 impl<'a, T> From<&'a Tet4Element<T>> for Tet10Element<T>
 where
-    T: RealField,
+    T: Real,
 {
     #[replace_float_literals(T::from_f64(literal).unwrap())]
     fn from(tet4_element: &'a Tet4Element<T>) -> Self {
@@ -110,7 +111,7 @@ where
 
 impl<T> Tet10Element<T>
 where
-    T: RealField,
+    T: Real,
 {
     #[replace_float_literals(T::from_f64(literal).unwrap())]
     pub fn reference() -> Self {
@@ -135,7 +136,7 @@ where
 #[replace_float_literals(T::from_f64(literal).unwrap())]
 impl<T> FixedNodesReferenceFiniteElement<T> for Tet10Element<T>
 where
-    T: RealField,
+    T: Real,
 {
     type ReferenceDim = U3;
     type NodalDim = U10;
@@ -190,7 +191,7 @@ where
 
 impl<T> FiniteElement<T> for Tet10Element<T>
 where
-    T: RealField,
+    T: Real,
 {
     type GeometryDim = U3;
 
@@ -221,7 +222,7 @@ where
 
 impl<T> Tet20Element<T>
 where
-    T: RealField,
+    T: Real,
 {
     pub fn from_tet4_vertices(vertices: [Point3<T>; 4]) -> Self {
         // TODO: Test this method
@@ -262,7 +263,7 @@ where
 
 impl<T> Tet20Element<T>
 where
-    T: RealField,
+    T: Real,
 {
     #[replace_float_literals(T::from_f64(literal).unwrap())]
     pub fn reference() -> Self {
@@ -309,7 +310,7 @@ where
 #[replace_float_literals(T::from_f64(literal).unwrap())]
 impl<T> FixedNodesReferenceFiniteElement<T> for Tet20Element<T>
 where
-    T: RealField,
+    T: Real,
 {
     type ReferenceDim = U3;
     type NodalDim = U20;
@@ -436,7 +437,7 @@ where
 
 impl<T> FiniteElement<T> for Tet20Element<T>
 where
-    T: RealField,
+    T: Real,
 {
     type GeometryDim = U3;
 
@@ -458,7 +459,7 @@ where
 
 impl<'a, T> From<&'a Tet4Element<T>> for Tet20Element<T>
 where
-    T: RealField,
+    T: Real,
 {
     fn from(tet4: &'a Tet4Element<T>) -> Self {
         // TODO: Test this!
@@ -489,7 +490,7 @@ where
 
 impl<T> Tet4Element<T>
 where
-    T: RealField,
+    T: Real,
 {
     #[replace_float_literals(T::from_f64(literal).unwrap())]
     pub fn reference() -> Self {
@@ -507,7 +508,7 @@ where
 #[replace_float_literals(T::from_f64(literal).unwrap())]
 impl<T> FixedNodesReferenceFiniteElement<T> for Tet4Element<T>
 where
-    T: RealField,
+    T: Real,
 {
     type ReferenceDim = U3;
     type NodalDim = U4;
@@ -535,7 +536,7 @@ where
 
 impl<T> FiniteElement<T> for Tet4Element<T>
 where
-    T: RealField,
+    T: Real,
 {
     type GeometryDim = U3;
 

--- a/src/element/triangle.rs
+++ b/src/element/triangle.rs
@@ -5,9 +5,10 @@ use crate::connectivity::{Tri3d2Connectivity, Tri3d3Connectivity, Tri6d2Connecti
 use crate::element::{ElementConnectivity, FiniteElement, FixedNodesReferenceFiniteElement, SurfaceFiniteElement};
 use crate::geometry::{LineSegment2d, Triangle, Triangle2d, Triangle3d};
 use crate::nalgebra::{
-    distance, Matrix1x3, Matrix1x6, Matrix2, Matrix2x3, Matrix2x6, Matrix3, Matrix3x2, OPoint, Point2, Point3,
-    RealField, Scalar, Vector2, Vector3, U2, U3, U6,
+    distance, Matrix1x3, Matrix1x6, Matrix2, Matrix2x3, Matrix2x6, Matrix3, Matrix3x2, OPoint, Point2, Point3, Scalar,
+    Vector2, Vector3, U2, U3, U6,
 };
+use crate::Real;
 
 /// A finite element representing linear basis functions on a triangle, in two dimensions.
 ///
@@ -46,7 +47,7 @@ where
 
 impl<T> Tri3d2Element<T>
 where
-    T: RealField,
+    T: Real,
 {
     #[replace_float_literals(T::from_f64(literal).unwrap())]
     pub fn reference() -> Self {
@@ -56,7 +57,7 @@ where
 
 impl<T> FixedNodesReferenceFiniteElement<T> for Tri3d2Element<T>
 where
-    T: RealField,
+    T: Real,
 {
     type NodalDim = U3;
     type ReferenceDim = U2;
@@ -85,7 +86,7 @@ where
 
 impl<T> FiniteElement<T> for Tri3d2Element<T>
 where
-    T: RealField,
+    T: Real,
 {
     type GeometryDim = U2;
 
@@ -148,7 +149,7 @@ where
 
 impl<'a, T> From<&'a Tri3d2Element<T>> for Tri6d2Element<T>
 where
-    T: RealField,
+    T: Real,
 {
     // TODO: Test this
     fn from(tri3: &'a Tri3d2Element<T>) -> Self {
@@ -167,7 +168,7 @@ where
 
 impl<'a, T> From<Tri3d2Element<T>> for Tri6d2Element<T>
 where
-    T: RealField,
+    T: Real,
 {
     fn from(tri3: Tri3d2Element<T>) -> Self {
         Self::from(&tri3)
@@ -176,7 +177,7 @@ where
 
 impl<T> Tri6d2Element<T>
 where
-    T: RealField,
+    T: Real,
 {
     #[replace_float_literals(T::from_f64(literal).unwrap())]
     pub fn reference() -> Self {
@@ -196,7 +197,7 @@ where
 
 impl<T> FixedNodesReferenceFiniteElement<T> for Tri6d2Element<T>
 where
-    T: RealField,
+    T: Real,
 {
     type NodalDim = U6;
     type ReferenceDim = U2;
@@ -245,7 +246,7 @@ where
 
 impl<T> FiniteElement<T> for Tri6d2Element<T>
 where
-    T: RealField,
+    T: Real,
 {
     type GeometryDim = U2;
 
@@ -264,7 +265,7 @@ where
 
 impl<T> ElementConnectivity<T> for Tri3d2Connectivity
 where
-    T: RealField,
+    T: Real,
 {
     type Element = Tri3d2Element<T>;
     type ReferenceDim = U2;
@@ -284,7 +285,7 @@ where
 
 impl<T> ElementConnectivity<T> for Tri6d2Connectivity
 where
-    T: RealField,
+    T: Real,
 {
     type Element = Tri6d2Element<T>;
     type ReferenceDim = U2;
@@ -346,7 +347,7 @@ where
 
 impl<T> FixedNodesReferenceFiniteElement<T> for Tri3d3Element<T>
 where
-    T: RealField,
+    T: Real,
 {
     type NodalDim = U3;
     type ReferenceDim = U2;
@@ -377,7 +378,7 @@ where
 
 impl<T> FiniteElement<T> for Tri3d3Element<T>
 where
-    T: RealField,
+    T: Real,
 {
     type GeometryDim = U3;
 
@@ -408,7 +409,7 @@ where
 
 impl<T> SurfaceFiniteElement<T> for Tri3d3Element<T>
 where
-    T: RealField,
+    T: Real,
 {
     fn normal(&self, _xi: &Point2<T>) -> Vector3<T> {
         Triangle3d::from(self).normal()
@@ -417,7 +418,7 @@ where
 
 impl<T> ElementConnectivity<T> for Tri3d3Connectivity
 where
-    T: RealField,
+    T: Real,
 {
     type Element = Tri3d3Element<T>;
     type ReferenceDim = U2;

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,9 +8,9 @@ use crate::integrate::{
     IntegrationWorkspace, VolumeFunction,
 };
 use crate::nalgebra::DVectorSlice;
-use crate::nalgebra::{DefaultAllocator, OPoint, OVector, RealField};
+use crate::nalgebra::{DefaultAllocator, OPoint, OVector};
 use crate::space::VolumetricFiniteElementSpace;
-use crate::SmallDim;
+use crate::{Real, SmallDim};
 use nalgebra::{OMatrix, Vector1, U1};
 
 /// Estimate the squared $L^2$ error $\norm{u_h - u}^2_{L^2}$ on the given element with the given basis
@@ -30,7 +30,7 @@ pub fn estimate_element_L2_error_squared<T, Element, SolutionDim>(
     workspace: &mut IntegrationWorkspace<T>,
 ) -> T
 where
-    T: RealField,
+    T: Real,
     Element: VolumetricFiniteElement<T>,
     SolutionDim: SmallDim,
     DefaultAllocator: TriDimAllocator<T, SolutionDim, Element::GeometryDim, Element::ReferenceDim>,
@@ -66,7 +66,7 @@ pub fn estimate_element_H1_seminorm_error_squared<T, Element, SolutionDim>(
     workspace: &mut IntegrationWorkspace<T>,
 ) -> T
 where
-    T: RealField,
+    T: Real,
     Element: VolumetricFiniteElement<T>,
     SolutionDim: SmallDim,
     DefaultAllocator: TriDimAllocator<T, SolutionDim, Element::GeometryDim, Element::ReferenceDim>,
@@ -103,7 +103,7 @@ pub fn estimate_element_H1_seminorm_error<T, Element, SolutionDim>(
     workspace: &mut IntegrationWorkspace<T>,
 ) -> T
 where
-    T: RealField,
+    T: Real,
     Element: VolumetricFiniteElement<T>,
     SolutionDim: SmallDim,
     DefaultAllocator: TriDimAllocator<T, SolutionDim, Element::GeometryDim, Element::ReferenceDim>,
@@ -136,7 +136,7 @@ pub fn estimate_element_L2_error<T, Element, SolutionDim>(
     workspace: &mut IntegrationWorkspace<T>,
 ) -> T
 where
-    T: RealField,
+    T: Real,
     Element: VolumetricFiniteElement<T>,
     SolutionDim: SmallDim,
     DefaultAllocator: TriDimAllocator<T, SolutionDim, Element::GeometryDim, Element::ReferenceDim>,
@@ -157,7 +157,7 @@ fn make_L2_error_squared_integrand<'a, T, SolutionDim, GeometryDim>(
     u: impl 'a + Fn(&OPoint<T, GeometryDim>) -> OVector<T, SolutionDim>,
 ) -> Integrand<SolutionDim, impl 'a + Fn(&OPoint<T, GeometryDim>, &OVector<T, SolutionDim>) -> Vector1<T>>
 where
-    T: RealField,
+    T: Real,
     SolutionDim: SmallDim,
     GeometryDim: SmallDim,
     DefaultAllocator: BiDimAllocator<T, SolutionDim, GeometryDim>,
@@ -175,7 +175,7 @@ fn make_H1_seminorm_error_squared_integrand<'a, T, SolutionDim, GeometryDim>(
     u_grad: impl 'a + Fn(&OPoint<T, GeometryDim>) -> OMatrix<T, GeometryDim, SolutionDim>,
 ) -> impl VolumeFunction<T, GeometryDim, SolutionDim = SolutionDim, OutputDim = U1>
 where
-    T: RealField,
+    T: Real,
     SolutionDim: SmallDim,
     GeometryDim: SmallDim,
     DefaultAllocator: BiDimAllocator<T, SolutionDim, GeometryDim>,
@@ -200,7 +200,7 @@ pub fn estimate_L2_error_squared<'a, T, Space, SolutionDim, QTable>(
     qtable: &QTable,
 ) -> eyre::Result<T>
 where
-    T: RealField,
+    T: Real,
     SolutionDim: SmallDim,
     Space: VolumetricFiniteElementSpace<T>,
     QTable: QuadratureTable<T, Space::ReferenceDim>,
@@ -226,7 +226,7 @@ pub fn estimate_L2_error<'a, T, Space, SolutionDim, QTable>(
     qtable: &QTable,
 ) -> eyre::Result<T>
 where
-    T: RealField,
+    T: Real,
     SolutionDim: SmallDim,
     Space: VolumetricFiniteElementSpace<T>,
     QTable: QuadratureTable<T, Space::ReferenceDim>,
@@ -245,7 +245,7 @@ pub fn estimate_H1_seminorm_error_squared<'a, T, Space, SolutionDim, QTable>(
     qtable: &QTable,
 ) -> eyre::Result<T>
 where
-    T: RealField,
+    T: Real,
     SolutionDim: SmallDim,
     Space: VolumetricFiniteElementSpace<T>,
     QTable: QuadratureTable<T, Space::ReferenceDim>,
@@ -271,7 +271,7 @@ pub fn estimate_H1_seminorm_error<'a, T, Space, SolutionDim, QTable>(
     qtable: &QTable,
 ) -> eyre::Result<T>
 where
-    T: RealField,
+    T: Real,
     SolutionDim: SmallDim,
     Space: VolumetricFiniteElementSpace<T>,
     QTable: QuadratureTable<T, Space::ReferenceDim>,

--- a/src/integrate.rs
+++ b/src/integrate.rs
@@ -10,9 +10,9 @@ use crate::quadrature::Quadrature;
 use crate::space::{ElementInSpace, FiniteElementSpace, VolumetricFiniteElementSpace};
 use crate::util::{reshape_to_slice, try_transmute_ref};
 use crate::workspace::with_thread_local_workspace;
-use crate::SmallDim;
+use crate::{Real, SmallDim};
 use eyre::eyre;
-use nalgebra::{DVectorSlice, Dynamic, OVector, RealField};
+use nalgebra::{DVectorSlice, Dynamic, OVector};
 use std::marker::PhantomData;
 
 /// Computes the Riemannian volume form for the given dimensions.
@@ -20,7 +20,7 @@ use std::marker::PhantomData;
 /// TODO: This is not actively tested at the moment, need to do this.
 pub fn volume_form<T, GeometryDim, ReferenceDim>(jacobian: &OMatrix<T, GeometryDim, ReferenceDim>) -> T
 where
-    T: RealField,
+    T: Real,
     GeometryDim: SmallDim,
     ReferenceDim: SmallDim,
     DefaultAllocator: BiDimAllocator<T, GeometryDim, ReferenceDim>,
@@ -189,7 +189,7 @@ pub struct IntegrationWorkspace<T: Scalar> {
     basis_buffer: BasisFunctionBuffer<T>,
 }
 
-impl<T: RealField> Default for IntegrationWorkspace<T> {
+impl<T: Real> Default for IntegrationWorkspace<T> {
     fn default() -> Self {
         Self {
             basis_buffer: BasisFunctionBuffer::default(),
@@ -206,7 +206,7 @@ pub fn integrate_over_element<'a, T, F, Element, QuadratureRule, IntoDVectorSlic
     workspace: &mut IntegrationWorkspace<T>,
 ) -> OVector<T, F::OutputDim>
 where
-    T: RealField,
+    T: Real,
     F: Function<T, Element::GeometryDim>,
     Element: FiniteElement<T>,
     QuadratureRule: Quadrature<T, Element::ReferenceDim>,
@@ -256,7 +256,7 @@ pub fn integrate_over_volume_element<'a, T, Element, F>(
     workspace: &mut IntegrationWorkspace<T>,
 ) -> Result<OVector<T, F::OutputDim>, IntegrationFailure>
 where
-    T: RealField,
+    T: Real,
     F: VolumeFunction<T, Element::GeometryDim>,
     Element: VolumetricFiniteElement<T>,
     DefaultAllocator:
@@ -475,7 +475,7 @@ where
 
 impl<T, D> Default for ElementIntegralAssemblerWorkspace<T, D>
 where
-    T: RealField,
+    T: Real,
     D: DimName,
     DefaultAllocator: DimAllocator<T, D>,
 {
@@ -491,7 +491,7 @@ where
 
 impl<'a, T, F, Space, QTable> ElementScalarAssembler<T> for ElementIntegralAssembler<'a, T, F, Space, QTable>
 where
-    T: RealField,
+    T: Real,
     F: Function<T, Space::GeometryDim>,
     Space: FiniteElementSpace<T>,
     QTable: QuadratureTable<T, Space::ReferenceDim>,
@@ -532,7 +532,7 @@ where
 
 impl<'a, T, F, Space, QTable> ElementConnectivityAssembler for ElementIntegralVolumeAssembler<'a, T, F, Space, QTable>
 where
-    T: RealField,
+    T: Real,
     // TODO: For some reason this only works if we specify Space::ReferenceDim. However, Space::GeometryDim would be
     // more appropriate, and we anyway have Space::GeometryDim == Space::ReferenceDim by definition of
     // a volumetric finite element space... But unsure if it may cause downstream issues
@@ -564,7 +564,7 @@ where
 
 impl<'a, T, F, Space, QTable> ElementScalarAssembler<T> for ElementIntegralVolumeAssembler<'a, T, F, Space, QTable>
 where
-    T: RealField,
+    T: Real,
     // TODO: See comment in impl for ElementConnectivityAssembler. Here we should ideally have Space::GeometryDim
     F: VolumeFunction<T, Space::ReferenceDim>,
     Space: VolumetricFiniteElementSpace<T>,

--- a/src/io/vtk.rs
+++ b/src/io/vtk.rs
@@ -1,5 +1,6 @@
 use crate::mesh::Mesh;
-use nalgebra::{DefaultAllocator, DimName, RealField, Scalar};
+use crate::Real;
+use nalgebra::{DefaultAllocator, DimName, Scalar};
 use vtkio::model::{Attribute, CellType, Cells, DataSet, UnstructuredGridPiece, VertexNumbers};
 
 use crate::connectivity::{
@@ -223,7 +224,7 @@ impl VtkCellConnectivity for Hex27Connectivity {
 //     quadrature_rules: impl IntoIterator<Item = impl Quadrature<T, C::ReferenceDim>>,
 // ) -> DataSet
 // where
-//     T: RealField,
+//     T: Real,
 //     D: DimName + DimMin<D, Output = D>,
 //     C: ElementConnectivity<T, GeometryDim = D, ReferenceDim = D>,
 //     DefaultAllocator: Allocator<T, D> + ElementConnectivityAllocator<T, C>,
@@ -320,7 +321,7 @@ where
 
 impl<'a, T, D, C> FiniteElementMeshDataSetBuilder<'a, T, D, C>
 where
-    T: RealField + ToPrimitive,
+    T: Real + ToPrimitive,
     D: DimName,
     DefaultAllocator: Allocator<T, D>,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,8 @@ pub extern crate nalgebra;
 pub extern crate nalgebra_sparse;
 pub extern crate vtkio;
 
+pub use fenris_traits::Real;
+
 /// A small, fixed-size dimension.
 ///
 /// Used as a trait alias for various traits frequently needed by generic `fenris` routines.

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -4,9 +4,10 @@ use crate::connectivity::{
     Tri3d2Connectivity, Tri3d3Connectivity, Tri6d2Connectivity,
 };
 use crate::geometry::{AxisAlignedBoundingBox, BoundedGeometry, GeometryCollection};
+use crate::Real;
 use fenris_nested_vec::NestedVec;
 use nalgebra::allocator::Allocator;
-use nalgebra::{DefaultAllocator, DimName, OPoint, OVector, RealField, Scalar, U2, U3};
+use nalgebra::{DefaultAllocator, DimName, OPoint, OVector, Scalar, U2, U3};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 use std::iter::once;
@@ -216,7 +217,7 @@ where
 
 impl<T, D, Connectivity> BoundedGeometry<T> for Mesh<T, D, Connectivity>
 where
-    T: RealField,
+    T: Real,
     D: DimName,
     DefaultAllocator: Allocator<T, D>,
     Connectivity: CellConnectivity<T, D>,
@@ -234,7 +235,7 @@ where
 
 impl<T, D, C> Mesh<T, D, C>
 where
-    T: RealField,
+    T: Real,
     D: DimName,
     DefaultAllocator: Allocator<T, D>,
 {
@@ -269,7 +270,7 @@ where
 
 impl<T> QuadMesh2d<T>
 where
-    T: RealField,
+    T: Real,
 {
     pub fn split_into_triangles(self) -> TriangleMesh2d<T> {
         let triangles = self
@@ -354,7 +355,7 @@ where
 
 // impl<T, Cell> Mesh2d<T, Cell>
 // where
-//     T: RealField,
+//     T: Real,
 //     Cell: Connectivity<FaceConnectivity = Segment2d2Connectivity>,
 // {
 //     pub fn extract_contour(&self) -> Result<GeneralPolygon<T>, Box<dyn Error>> {
@@ -536,7 +537,7 @@ where
 
 // impl<'a, T, D, C, QueryGeometry> DistanceQuery<'a, QueryGeometry> for Mesh<T, D, C>
 // where
-//     T: RealField,
+//     T: Real,
 //     D: DimName,
 //     C: CellConnectivity<T, D>,
 //     C::Cell: Distance<T, QueryGeometry>,
@@ -578,7 +579,7 @@ where
 //
 // impl<T> PlanarFace<T> for LineSegment2d<T>
 // where
-//     T: RealField,
+//     T: Real,
 // {
 //     type Dimension = U2;
 //

--- a/src/mesh/procedural.rs
+++ b/src/mesh/procedural.rs
@@ -4,7 +4,8 @@ use crate::geometry::polymesh::PolyMesh3d;
 use crate::geometry::sdf::BoundedSdf;
 use crate::geometry::{AxisAlignedBoundingBox2d, HalfSpace};
 use crate::mesh::{HexMesh, Mesh, QuadMesh2d, Tet4Mesh, TriangleMesh2d};
-use nalgebra::{convert, try_convert, Point2, Point3, RealField, Unit, Vector2, Vector3};
+use crate::Real;
+use nalgebra::{convert, try_convert, Point2, Point3, Unit, Vector2, Vector3};
 use numeric_literals::replace_float_literals;
 use ordered_float::NotNan;
 use std::cmp::min;
@@ -12,14 +13,14 @@ use std::f64::consts::PI;
 
 pub fn create_unit_square_uniform_quad_mesh_2d<T>(cells_per_dim: usize) -> QuadMesh2d<T>
 where
-    T: RealField,
+    T: Real,
 {
     create_rectangular_uniform_quad_mesh_2d(T::one(), 1, 1, cells_per_dim, &Vector2::new(T::zero(), T::one()))
 }
 
 pub fn create_unit_square_uniform_tri_mesh_2d<T>(cells_per_dim: usize) -> TriangleMesh2d<T>
 where
-    T: RealField,
+    T: Real,
 {
     create_rectangular_uniform_quad_mesh_2d(T::one(), 1, 1, cells_per_dim, &Vector2::new(T::zero(), T::one()))
         .split_into_triangles()
@@ -27,14 +28,14 @@ where
 
 pub fn create_unit_box_uniform_hex_mesh_3d<T>(cells_per_dim: usize) -> HexMesh<T>
 where
-    T: RealField,
+    T: Real,
 {
     create_rectangular_uniform_hex_mesh(T::one(), 1, 1, 1, cells_per_dim)
 }
 
 pub fn create_unit_box_uniform_tet_mesh_3d<T>(cells_per_dim: usize) -> Tet4Mesh<T>
 where
-    T: RealField,
+    T: Real,
 {
     let hex_mesh = create_unit_box_uniform_hex_mesh_3d(cells_per_dim);
     Tet4Mesh::from(&hex_mesh)
@@ -50,7 +51,7 @@ pub fn create_rectangular_uniform_quad_mesh_2d<T>(
     top_left: &Vector2<T>,
 ) -> QuadMesh2d<T>
 where
-    T: RealField,
+    T: Real,
 {
     if cells_per_unit == 0 || units_x == 0 || units_y == 0 {
         QuadMesh2d::from_vertices_and_connectivity(Vec::new(), Vec::new())
@@ -94,7 +95,7 @@ where
 #[replace_float_literals(T::from_f64(literal).expect("Literal must fit in T"))]
 pub fn voxelize_bounding_box_2d<T>(bounds: &AxisAlignedBoundingBox2d<T>, max_cell_size: T) -> QuadMesh2d<T>
 where
-    T: RealField,
+    T: Real,
 {
     assert!(max_cell_size > T::zero(), "Max cell size must be positive.");
 
@@ -138,7 +139,7 @@ where
 #[replace_float_literals(T::from_f64(literal).expect("Literal must fit in T"))]
 pub fn voxelize_sdf_2d<T>(sdf: &impl BoundedSdf<T>, max_cell_size: T) -> QuadMesh2d<T>
 where
-    T: RealField,
+    T: Real,
 {
     let rectangular_mesh: QuadMesh2d<T> = voxelize_bounding_box_2d(&sdf.bounding_box(), max_cell_size);
     let desired_cell_indices: Vec<_> = rectangular_mesh
@@ -154,7 +155,7 @@ where
 #[replace_float_literals(T::from_f64(literal).expect("Literal must fit in T"))]
 pub fn approximate_quad_mesh_for_sdf_2d<T>(sdf: &impl BoundedSdf<T>, max_cell_size: T) -> QuadMesh2d<T>
 where
-    T: RealField,
+    T: Real,
 {
     let mut mesh = voxelize_sdf_2d(sdf, max_cell_size);
 
@@ -172,7 +173,7 @@ where
 
 pub fn approximate_triangle_mesh_for_sdf_2d<T>(sdf: &impl BoundedSdf<T>, max_cell_size: T) -> TriangleMesh2d<T>
 where
-    T: RealField,
+    T: Real,
 {
     // TODO: This is not the most efficient way to do this, since we compute SDFs for the same points
     // several times, but it's at least simple
@@ -220,7 +221,7 @@ pub fn create_rectangular_uniform_hex_mesh<T>(
     cells_per_unit: usize,
 ) -> HexMesh<T>
 where
-    T: RealField,
+    T: Real,
 {
     if cells_per_unit == 0 || units_x == 0 || units_y == 0 {
         HexMesh::from_vertices_and_connectivity(Vec::new(), Vec::new())

--- a/src/mesh_convert.rs
+++ b/src/mesh_convert.rs
@@ -5,10 +5,11 @@ use crate::connectivity::{
 use crate::element::{ElementConnectivity, FiniteElement};
 use crate::mesh::{HexMesh, Mesh, Mesh2d, Mesh3d, Tet4Mesh};
 use nalgebra::allocator::Allocator;
-use nalgebra::{DefaultAllocator, DimName, OPoint, Point2, Point3, RealField, Scalar, U3};
+use nalgebra::{DefaultAllocator, DimName, OPoint, Point2, Point3, Scalar, U3};
 
 use crate::geometry::polymesh::{PolyMesh, PolyMesh3d};
 use crate::geometry::{OrientationTestResult, Triangle};
+use crate::Real;
 use fenris_nested_vec::NestedVec;
 use itertools::{izip, Itertools};
 use numeric_literals::replace_float_literals;
@@ -39,7 +40,7 @@ where
 
 impl<T> RefineFrom<T, U3, Tet4Connectivity> for Tet10Connectivity
 where
-    T: RealField,
+    T: Real,
     DefaultAllocator: Allocator<T, U3>,
 {
     fn refine(
@@ -82,7 +83,7 @@ where
 
 impl<T> RefineFrom<T, U3, Hex8Connectivity> for Hex27Connectivity
 where
-    T: RealField,
+    T: Real,
     DefaultAllocator: Allocator<T, U3>,
 {
     #[replace_float_literals(T::from_f64(literal).unwrap())]
@@ -165,7 +166,7 @@ where
 
 impl<T> RefineFrom<T, U3, Hex8Connectivity> for Hex20Connectivity
 where
-    T: RealField,
+    T: Real,
     DefaultAllocator: Allocator<T, U3>,
 {
     #[replace_float_literals(T::from_f64(literal).unwrap())]
@@ -224,7 +225,7 @@ pub trait FromTemp<T> {
 
 impl<'a, T, D, C, CNew> FromTemp<&'a Mesh<T, D, C>> for Mesh<T, D, CNew>
 where
-    T: RealField,
+    T: Real,
     D: DimName,
     C: Connectivity,
     CNew: RefineFrom<T, D, C>,
@@ -329,7 +330,7 @@ where
 
 impl<T> From<Mesh2d<T, Tri3d2Connectivity>> for Mesh2d<T, Tri6d2Connectivity>
 where
-    T: RealField,
+    T: Real,
 {
     #[replace_float_literals(T::from_f64(literal).expect("Literal must fit in T"))]
     fn from(initial_mesh: Mesh2d<T, Tri3d2Connectivity>) -> Self {
@@ -382,7 +383,7 @@ where
 
 impl<T> From<Mesh2d<T, Quad4d2Connectivity>> for Mesh2d<T, Quad9d2Connectivity>
 where
-    T: RealField,
+    T: Real,
 {
     #[replace_float_literals(T::from_f64(literal).expect("Literal must fit in T"))]
     fn from(initial_mesh: Mesh2d<T, Quad4d2Connectivity>) -> Self {
@@ -441,7 +442,7 @@ where
 
 impl<'a, T> From<&'a Mesh3d<T, Tet4Connectivity>> for Mesh3d<T, Tet10Connectivity>
 where
-    T: RealField,
+    T: Real,
 {
     #[replace_float_literals(T::from_f64(literal).expect("Literal must fit in T"))]
     fn from(initial_mesh: &'a Mesh3d<T, Tet4Connectivity>) -> Self {
@@ -451,7 +452,7 @@ where
 
 impl<'a, T> From<&'a Mesh3d<T, Tet10Connectivity>> for Mesh3d<T, Tet4Connectivity>
 where
-    T: RealField,
+    T: Real,
 {
     #[replace_float_literals(T::from_f64(literal).expect("Literal must fit in T"))]
     fn from(initial_mesh: &'a Mesh3d<T, Tet10Connectivity>) -> Self {
@@ -469,7 +470,7 @@ where
 
 impl<'a, T> From<&'a Mesh3d<T, Hex8Connectivity>> for Mesh3d<T, Hex27Connectivity>
 where
-    T: RealField,
+    T: Real,
 {
     fn from(initial_mesh: &'a Mesh3d<T, Hex8Connectivity>) -> Self {
         <Self as FromTemp<_>>::from(initial_mesh)
@@ -478,7 +479,7 @@ where
 
 impl<'a, T> From<&'a Mesh3d<T, Hex8Connectivity>> for Mesh3d<T, Hex20Connectivity>
 where
-    T: RealField,
+    T: Real,
 {
     fn from(initial_mesh: &'a Mesh3d<T, Hex8Connectivity>) -> Self {
         <Self as FromTemp<_>>::from(initial_mesh)
@@ -487,11 +488,11 @@ where
 
 impl<'a, T> From<&'a HexMesh<T>> for Tet4Mesh<T>
 where
-    T: RealField,
+    T: Real,
 {
     fn from(hex_mesh: &'a HexMesh<T>) -> Self {
         // TODO: Provide a "direct" method that does not rely on triangulation
-        // (then we could also reduce the `RealField` bound to `Scalar`)
+        // (then we could also reduce the `Real` bound to `Scalar`)
         let poly_mesh = PolyMesh3d::from(hex_mesh)
             .triangulate()
             .expect("Must be able to triangulate hex mesh");
@@ -562,7 +563,7 @@ where
 
 impl<'a, T> TryFrom<&'a PolyMesh3d<T>> for Tet4Mesh<T>
 where
-    T: RealField,
+    T: Real,
 {
     // TODO: Proper Error type
     type Error = Box<dyn Error>;

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,8 +1,9 @@
 use crate::allocators::BiDimAllocator;
 use crate::geometry::DistanceQuery;
 use crate::space::GeometricFiniteElementSpace;
+use crate::Real;
 use nalgebra::allocator::Allocator;
-use nalgebra::{DVector, DefaultAllocator, DimMin, DimName, OPoint, OVector, RealField, U1};
+use nalgebra::{DVector, DefaultAllocator, DimMin, DimName, OPoint, OVector, U1};
 use serde::{Deserialize, Serialize};
 
 /// Interpolates solution variables onto a fixed set of interpolation points.
@@ -35,7 +36,7 @@ pub struct FiniteElementInterpolator<T> {
 
 impl<T> FiniteElementInterpolator<T>
 where
-    T: RealField,
+    T: Real,
 {
     pub fn interpolate<SolutionDim>(&self, u: &DVector<T>) -> Vec<OVector<T, SolutionDim>>
     where
@@ -101,7 +102,7 @@ impl<T> FiniteElementInterpolator<T> {
         _interpolation_points: &'a [OPoint<T, D>],
     ) -> Result<Self, Box<dyn std::error::Error>>
     where
-        T: RealField,
+        T: Real,
         D: DimName + DimMin<D, Output = D>,
         Space: GeometricFiniteElementSpace<'a, T, GeometryDim = D> + DistanceQuery<'a, OPoint<T, D>>,
         DefaultAllocator: BiDimAllocator<T, Space::GeometryDim, Space::ReferenceDim>,
@@ -146,7 +147,7 @@ impl<T> FiniteElementInterpolator<T> {
 
 pub trait MakeInterpolator<T, D>
 where
-    T: RealField,
+    T: Real,
     D: DimName + DimMin<D, Output = D>,
     DefaultAllocator: Allocator<T, D>,
 {

--- a/src/quadrature.rs
+++ b/src/quadrature.rs
@@ -1,3 +1,5 @@
+use crate::nalgebra::{convert, Point2, Point3, U1};
+use crate::Real;
 use nalgebra::allocator::Allocator;
 use nalgebra::{DefaultAllocator, DimName, OPoint, Point1, Scalar, U2, U3};
 use num::Zero;
@@ -10,8 +12,6 @@ pub use canonical::*;
 ///
 /// TODO: How to prevent collapse?
 pub use fenris_quadrature::Error as QuadratureError;
-
-use crate::nalgebra::{convert, Point2, Point3, RealField, U1};
 
 pub mod subdivide;
 pub mod tensor;
@@ -287,7 +287,7 @@ where
 
 fn convert_quadrature_rule_from_1d_f64<T>(quadrature: fenris_quadrature::Rule<1>) -> QuadraturePair1d<T>
 where
-    T: RealField,
+    T: Real,
 {
     let (weights, points) = quadrature;
     let weights = weights.into_iter().map(convert).collect();
@@ -297,7 +297,7 @@ where
 
 fn convert_quadrature_rule_from_2d_f64<T>(quadrature: fenris_quadrature::Rule<2>) -> QuadraturePair2d<T>
 where
-    T: RealField,
+    T: Real,
 {
     let (weights, points) = quadrature;
     let weights = weights.into_iter().map(convert).collect();
@@ -307,7 +307,7 @@ where
 
 fn convert_quadrature_rule_from_3d_f64<T>(quadrature: fenris_quadrature::Rule<3>) -> QuadraturePair3d<T>
 where
-    T: RealField,
+    T: Real,
 {
     let (weights, points) = quadrature;
     let weights = weights.into_iter().map(convert).collect();

--- a/src/quadrature/canonical.rs
+++ b/src/quadrature/canonical.rs
@@ -6,7 +6,7 @@ use crate::mesh::Mesh;
 use crate::nalgebra::{DefaultAllocator, DimName, Scalar};
 use crate::quadrature::QuadraturePair;
 use crate::quadrature::{tensor, total_order};
-use nalgebra::RealField;
+use crate::Real;
 
 /// A canonical quadrature for integrating the mass matrix terms.
 ///
@@ -38,7 +38,7 @@ macro_rules! impl_canonical_mass_for_element {
     ($element:ty, $quadrature:expr) => {
         impl<T> CanonicalMassQuadrature for $element
         where
-            T: RealField,
+            T: Real,
         {
             type Quadrature = QuadraturePair<T, <$element as ReferenceFiniteElement<T>>::ReferenceDim>;
 
@@ -53,7 +53,7 @@ macro_rules! impl_canonical_stiffness_for_element {
     ($element:ty, $quadrature:expr) => {
         impl<T> CanonicalStiffnessQuadrature for $element
         where
-            T: RealField,
+            T: Real,
         {
             type Quadrature = QuadraturePair<T, <$element as ReferenceFiniteElement<T>>::ReferenceDim>;
 

--- a/src/quadrature/subdivide.rs
+++ b/src/quadrature/subdivide.rs
@@ -4,8 +4,9 @@ use crate::integrate::volume_form;
 use crate::quadrature::{
     BorrowedQuadratureParts, Quadrature, Quadrature1d, Quadrature2d, QuadraturePair1d, QuadraturePair2d,
 };
+use crate::Real;
 use itertools::izip;
-use nalgebra::{point, vector, Point1, Point2, RealField, U2};
+use nalgebra::{point, vector, Point1, Point2, U2};
 use numeric_literals::replace_float_literals;
 
 /// Construct a univariate quadrature rule by subdivision.
@@ -16,7 +17,7 @@ use numeric_literals::replace_float_literals;
 /// an aggregate quadrature rule from the individual pieces.
 pub fn subdivide_univariate<T>(quadrature: impl Quadrature1d<T>, subdivision_pieces: usize) -> QuadraturePair1d<T>
 where
-    T: RealField,
+    T: Real,
 {
     subdivide_univariate_(quadrature.weights(), quadrature.points(), subdivision_pieces)
 }
@@ -28,7 +29,7 @@ fn subdivide_univariate_<T>(
     subdivision_pieces: usize,
 ) -> QuadraturePair1d<T>
 where
-    T: RealField,
+    T: Real,
 {
     let mut points = Vec::new();
     let mut weights = Vec::new();
@@ -72,7 +73,7 @@ where
 /// Panics if `subdivisions == 0`.
 pub fn subdivide_triangle<T>(quadrature: impl Quadrature2d<T, Data = ()>, subdivisions: usize) -> QuadraturePair2d<T>
 where
-    T: RealField,
+    T: Real,
 {
     subdivide_triangle_(quadrature.to_parts(), subdivisions)
 }
@@ -83,7 +84,7 @@ fn subdivide_triangle_<T>(
     subdivisions: usize,
 ) -> QuadraturePair2d<T>
 where
-    T: RealField,
+    T: Real,
 {
     assert!(
         subdivisions > 0,
@@ -123,7 +124,7 @@ where
     quadrature
 }
 
-fn add_triangle_quadrature<T: RealField>(
+fn add_triangle_quadrature<T: Real>(
     quadrature: &mut QuadraturePair2d<T>,
     triangle_vertices: [Point2<T>; 3],
     base_quadrature: BorrowedQuadratureParts<T, U2, ()>,

--- a/src/quadrature/tensor.rs
+++ b/src/quadrature/tensor.rs
@@ -1,16 +1,16 @@
 //! Quadrature rules constructed from products of 1D quadrature rules.
-use crate::nalgebra::RealField;
 use crate::quadrature::{
     convert_quadrature_rule_from_2d_f64, convert_quadrature_rule_from_3d_f64, QuadraturePair2d, QuadraturePair3d,
 };
+use crate::Real;
 use fenris_quadrature::tensor;
 
-pub fn quadrilateral_gauss<T: RealField>(num_points_per_dim: usize) -> QuadraturePair2d<T> {
+pub fn quadrilateral_gauss<T: Real>(num_points_per_dim: usize) -> QuadraturePair2d<T> {
     let (weights, points) = tensor::quadrilateral_gauss(num_points_per_dim);
     convert_quadrature_rule_from_2d_f64((weights, points))
 }
 
-pub fn hexahedron_gauss<T: RealField>(num_points_per_dim: usize) -> QuadraturePair3d<T> {
+pub fn hexahedron_gauss<T: Real>(num_points_per_dim: usize) -> QuadraturePair3d<T> {
     let (weights, points) = tensor::hexahedron_gauss(num_points_per_dim);
     convert_quadrature_rule_from_3d_f64((weights, points))
 }

--- a/src/quadrature/total_order.rs
+++ b/src/quadrature/total_order.rs
@@ -6,36 +6,36 @@
 
 use fenris_quadrature::polyquad;
 
-use crate::nalgebra::RealField;
 use crate::quadrature;
 use crate::quadrature::{QuadratureError, QuadraturePair2d, QuadraturePair3d};
+use crate::Real;
 
-pub fn triangle<T: RealField>(strength: usize) -> Result<QuadraturePair2d<T>, QuadratureError> {
+pub fn triangle<T: Real>(strength: usize) -> Result<QuadraturePair2d<T>, QuadratureError> {
     let (weights, points) = polyquad::triangle(strength)?;
     Ok(quadrature::convert_quadrature_rule_from_2d_f64((weights, points)))
 }
 
-pub fn quadrilateral<T: RealField>(strength: usize) -> Result<QuadraturePair2d<T>, QuadratureError> {
+pub fn quadrilateral<T: Real>(strength: usize) -> Result<QuadraturePair2d<T>, QuadratureError> {
     let (weights, points) = polyquad::quadrilateral(strength)?;
     Ok(quadrature::convert_quadrature_rule_from_2d_f64((weights, points)))
 }
 
-pub fn tetrahedron<T: RealField>(strength: usize) -> Result<QuadraturePair3d<T>, QuadratureError> {
+pub fn tetrahedron<T: Real>(strength: usize) -> Result<QuadraturePair3d<T>, QuadratureError> {
     let (weights, points) = polyquad::tetrahedron(strength)?;
     Ok(quadrature::convert_quadrature_rule_from_3d_f64((weights, points)))
 }
 
-pub fn hexahedron<T: RealField>(strength: usize) -> Result<QuadraturePair3d<T>, QuadratureError> {
+pub fn hexahedron<T: Real>(strength: usize) -> Result<QuadraturePair3d<T>, QuadratureError> {
     let (weights, points) = polyquad::hexahedron(strength)?;
     Ok(quadrature::convert_quadrature_rule_from_3d_f64((weights, points)))
 }
 
-pub fn prism<T: RealField>(strength: usize) -> Result<QuadraturePair3d<T>, QuadratureError> {
+pub fn prism<T: Real>(strength: usize) -> Result<QuadraturePair3d<T>, QuadratureError> {
     let (weights, points) = polyquad::prism(strength)?;
     Ok(quadrature::convert_quadrature_rule_from_3d_f64((weights, points)))
 }
 
-pub fn pyramid<T: RealField>(strength: usize) -> Result<QuadraturePair3d<T>, QuadratureError> {
+pub fn pyramid<T: Real>(strength: usize) -> Result<QuadraturePair3d<T>, QuadratureError> {
     let (weights, points) = polyquad::pyramid(strength)?;
     Ok(quadrature::convert_quadrature_rule_from_3d_f64((weights, points)))
 }

--- a/src/quadrature/univariate.rs
+++ b/src/quadrature/univariate.rs
@@ -1,13 +1,13 @@
 //! Quadrature rules for 1D domains.
-use crate::nalgebra::RealField;
 use crate::quadrature::{convert_quadrature_rule_from_1d_f64, QuadraturePair1d};
+use crate::Real;
 use fenris_quadrature::univariate;
 
-pub fn gauss<T: RealField>(num_points: usize) -> QuadraturePair1d<T> {
+pub fn gauss<T: Real>(num_points: usize) -> QuadraturePair1d<T> {
     let (weights, points) = univariate::gauss(num_points);
     convert_quadrature_rule_from_1d_f64((weights, points))
 }
 
-pub fn try_gauss_lobatto<T: RealField>(num_points: usize) -> Option<QuadraturePair1d<T>> {
+pub fn try_gauss_lobatto<T: Real>(num_points: usize) -> Option<QuadraturePair1d<T>> {
     univariate::try_gauss_lobatto(num_points).map(convert_quadrature_rule_from_1d_f64)
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,3 +1,4 @@
+use crate::Real;
 use itertools::izip;
 use itertools::Itertools;
 use nalgebra::allocator::Allocator;
@@ -5,8 +6,8 @@ use nalgebra::constraint::{DimEq, ShapeConstraint};
 use nalgebra::storage::{ContiguousStorage, Storage, StorageMut};
 use nalgebra::{
     DMatrixSlice, DVector, DVectorSlice, DefaultAllocator, Dim, DimDiff, DimMin, DimMul, DimName, DimProd, DimSub,
-    Matrix, Matrix3, MatrixSlice, MatrixSliceMut, OMatrix, OPoint, OVector, Quaternion, RealField, Scalar,
-    SliceStorage, SliceStorageMut, SquareMatrix, UnitQuaternion, Vector, Vector3, U1,
+    Matrix, Matrix3, MatrixSlice, MatrixSliceMut, OMatrix, OPoint, OVector, Quaternion, Scalar, SliceStorage,
+    SliceStorageMut, SquareMatrix, UnitQuaternion, Vector, Vector3, U1,
 };
 use nalgebra_sparse::{CooMatrix, CsrMatrix};
 use num::Zero;
@@ -120,7 +121,7 @@ where
 /// Returns a tuple `(U, S, V^T)`.
 pub fn rotation_svd<T, D>(matrix: &OMatrix<T, D, D>) -> (OMatrix<T, D, D>, OVector<T, D>, OMatrix<T, D, D>)
 where
-    T: RealField,
+    T: Real,
     D: DimName + DimMin<D, Output = D> + DimSub<U1>,
     DefaultAllocator:
         Allocator<T, D> + Allocator<T, D, D> + Allocator<T, <D as DimSub<U1>>::Output> + Allocator<(usize, usize), D>,
@@ -162,7 +163,7 @@ where
 ///
 #[allow(non_snake_case)]
 #[replace_float_literals(T::from_f64(literal).unwrap())]
-pub fn apd<T: RealField>(
+pub fn apd<T: Real>(
     deformation_grad: &Matrix3<T>,
     initial_guess: &UnitQuaternion<T>,
     max_iter: usize,
@@ -238,7 +239,7 @@ pub fn apd<T: RealField>(
 
 pub fn diag_left_mul<T, D1, D2, S>(diag: &Vector<T, D1, S>, matrix: &OMatrix<T, D1, D2>) -> OMatrix<T, D1, D2>
 where
-    T: RealField,
+    T: Real,
     D1: DimName,
     D2: DimName,
     S: Storage<T, D1>,
@@ -308,7 +309,7 @@ pub fn try_transmute_ref_mut<T: 'static, U: 'static>(e: &mut T) -> Option<&mut U
     }
 }
 
-pub fn cross_product_matrix<T: RealField>(x: &Vector3<T>) -> Matrix3<T> {
+pub fn cross_product_matrix<T: Real>(x: &Vector3<T>) -> Matrix3<T> {
     Matrix3::new(T::zero(), -x[2], x[1], x[2], T::zero(), -x[0], -x[1], x[0], T::zero())
 }
 
@@ -396,7 +397,7 @@ pub fn dump_csr_matrix_to_mm_file<T: Scalar + LowerExp>(
 
 pub fn min_eigenvalue_symmetric<T, D, S>(matrix: &SquareMatrix<T, D, S>) -> T
 where
-    T: RealField,
+    T: Real,
     D: Dim + DimSub<U1>,
     S: Storage<T, D, D>,
     DefaultAllocator:
@@ -430,7 +431,7 @@ where
 
 pub fn min_max_symmetric_eigenvalues<T, D, S>(matrix: &SquareMatrix<T, D, S>) -> (T, T)
 where
-    T: RealField,
+    T: Real,
     D: Dim + DimSub<U1>,
     S: Storage<T, D, D>,
     DefaultAllocator:
@@ -448,7 +449,7 @@ where
 
 pub fn condition_number_symmetric<T, D, S>(matrix: &SquareMatrix<T, D, S>) -> T
 where
-    T: RealField,
+    T: Real,
     D: Dim + DimSub<U1>,
     S: Storage<T, D, D>,
     DefaultAllocator:
@@ -469,7 +470,7 @@ where
 /*
 pub fn condition_number_csr<T>(matrix: &CsrMatrix<T>) -> T
 where
-    T: RealField + mkl_corrode::SupportedScalar,
+    T: Real + mkl_corrode::SupportedScalar,
 {
     assert_eq!(
         matrix.nrows(),
@@ -666,7 +667,7 @@ pub fn compute_interpolation<'a, 'b, T, SolutionDim>(
     basis: impl Into<DVectorSlice<'b, T>>,
 ) -> OVector<T, SolutionDim>
 where
-    T: RealField,
+    T: Real,
     SolutionDim: SmallDim,
     DefaultAllocator: DimAllocator<T, SolutionDim>,
 {
@@ -675,7 +676,7 @@ where
 
 fn compute_interpolation_<T, SolutionDim>(u: DVectorSlice<T>, basis: DVectorSlice<T>) -> OVector<T, SolutionDim>
 where
-    T: RealField,
+    T: Real,
     SolutionDim: SmallDim,
     DefaultAllocator: DimAllocator<T, SolutionDim>,
 {
@@ -727,7 +728,7 @@ pub fn compute_interpolation_gradient<'a, T, SolutionDim, GeometryDim>(
     basis_gradients: impl Into<DVectorSlice<'a, T>>,
 ) -> OMatrix<T, GeometryDim, SolutionDim>
 where
-    T: RealField,
+    T: Real,
     SolutionDim: SmallDim,
     GeometryDim: SmallDim,
     DefaultAllocator: BiDimAllocator<T, GeometryDim, SolutionDim>,
@@ -740,7 +741,7 @@ fn compute_interpolation_gradient_<T, SolutionDim, GeometryDim>(
     basis_gradients: DVectorSlice<T>,
 ) -> OMatrix<T, GeometryDim, SolutionDim>
 where
-    T: RealField,
+    T: Real,
     SolutionDim: SmallDim,
     GeometryDim: SmallDim,
     DefaultAllocator: BiDimAllocator<T, GeometryDim, SolutionDim>,

--- a/tests/unit_tests/assembly.rs
+++ b/tests/unit_tests/assembly.rs
@@ -14,7 +14,7 @@ mod local;
 //
 // impl<T> ElasticMaterialModel<T, U2> for MockIdentityMaterial
 // where
-//     T: RealField,
+//     T: Real,
 // {
 //     fn compute_strain_energy_density(&self, _deformation_gradient: &Matrix2<T>) -> T {
 //         unimplemented!()
@@ -40,7 +40,7 @@ mod local;
 // #[allow(non_snake_case)]
 // impl<T> ElasticMaterialModel<T, U2> for MockSimpleMaterial
 // where
-//     T: RealField,
+//     T: Real,
 // {
 //     fn compute_strain_energy_density(&self, _deformation_gradient: &Matrix2<T>) -> T {
 //         unimplemented!()

--- a/tests/unit_tests/assembly/local.rs
+++ b/tests/unit_tests/assembly/local.rs
@@ -10,9 +10,10 @@ use fenris::element::{Quad4d2Element, VolumetricFiniteElement};
 use fenris::geometry::Quad2d;
 use fenris::mesh::procedural::create_unit_square_uniform_quad_mesh_2d;
 use fenris::mesh::QuadMesh2d;
-use fenris::nalgebra::{DMatrix, DVector, DefaultAllocator, DimName, Matrix4, OPoint, OVector, Point2, RealField};
+use fenris::nalgebra::{DMatrix, DVector, DefaultAllocator, DimName, Matrix4, OPoint, OVector, Point2};
 use fenris::quadrature;
 use fenris::quadrature::QuadraturePair;
+use fenris::Real;
 use itertools::izip;
 use matrixcompare::{assert_matrix_eq, assert_scalar_eq};
 use nalgebra::{DMatrixSliceMut, Matrix2};
@@ -24,7 +25,7 @@ mod source;
 
 fn reference_quad<T>() -> Quad2d<T>
 where
-    T: RealField,
+    T: Real,
 {
     Quad2d([
         Point2::new(-T::one(), -T::one()),

--- a/tests/unit_tests/basis.rs
+++ b/tests/unit_tests/basis.rs
@@ -40,7 +40,7 @@ fn interpolate_into() {
 // TODO: Use this in rewritten tests?
 // fn find_interior_point<T>(polygon: &ConvexPolygon<T>) -> Point2<T>
 // where
-//     T: RealField,
+//     T: Real,
 // {
 //     // Find an interior point by averaging all vertices (note: this is not in general the centroid)
 //     let num_vertices = polygon.vertices().len();

--- a/tests/unit_tests/quadrature/canonical.rs
+++ b/tests/unit_tests/quadrature/canonical.rs
@@ -2,11 +2,12 @@ use fenris::allocators::BiDimAllocator;
 use fenris::assembly::local::{assemble_element_elliptic_matrix, assemble_element_mass_matrix};
 use fenris::assembly::operators::LaplaceOperator;
 use fenris::element::*;
-use fenris::nalgebra::{DefaultAllocator, Dynamic, RealField};
+use fenris::nalgebra::{DefaultAllocator, Dynamic};
 use fenris::quadrature;
 use fenris::quadrature::{
     CanonicalMassQuadrature, CanonicalStiffnessQuadrature, Quadrature, QuadraturePair2d, QuadraturePair3d,
 };
+use fenris::Real;
 use matrixcompare::comparators::FloatElementwiseComparator;
 use matrixcompare::{assert_matrix_eq, compare_matrices};
 use nalgebra::{DMatrix, DMatrixSliceMut, DVector, DVectorSlice, MatrixSliceMut, OMatrix, U2, U3};
@@ -17,7 +18,7 @@ fn assemble_mass_for_element<T, Element>(
     quadrature: impl Quadrature<T, Element::ReferenceDim>,
 ) -> DMatrix<T>
 where
-    T: RealField,
+    T: Real,
     Element: VolumetricFiniteElement<T>,
     DefaultAllocator: BiDimAllocator<T, Element::GeometryDim, Element::ReferenceDim>,
 {
@@ -42,7 +43,7 @@ fn assemble_stiffness_for_element<T, Element>(
     quadrature: impl Quadrature<T, Element::ReferenceDim>,
 ) -> DMatrix<T>
 where
-    T: RealField,
+    T: Real,
     Element: VolumetricFiniteElement<T>,
     DefaultAllocator: BiDimAllocator<T, Element::GeometryDim, Element::ReferenceDim>,
 {

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nalgebra = "0.28"
+nalgebra = "0.31"
 num = "0.4"


### PR DESCRIPTION
`nalgebra 0.29` removed the `Copy` requirement for `RealField` types. For now, we work around this by introducing a `fenris-traits` crate with a trait alias `Real: RealField + Copy`. Long term there should be some more sweeping reforms of traits in `nalgebra`, which is why we postpone removing the `Copy` bound in our code for now.