### PR TITLE
Faster pattern assembly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,11 +37,11 @@ jobs:
           key: ${{ runner.os }}-cargo-check-${{ hashFiles('**/Cargo.toml') }}
       - uses: dtolnay/rust-toolchain@stable
       - name: Check
-        run: cargo check --verbose
+        run: cargo check --workspace --all-targets --verbose
       - name: Check tests
-        run: cargo check --tests --verbose
+        run: cargo check --workspace --tests --verbose
       - name: Check examples
-        run: cargo check --examples --verbose
+        run: cargo check --workspace --examples --verbose
 
   cargo-doc:
     
@@ -83,9 +83,11 @@ jobs:
       - name: Build tests, release (cargo build --tests --workspace --all-targets --release)
         run: cargo build --tests --workspace --all-targets --release
       - name: Run tests without convergence tests
-        run: cargo test --workspace --all-targets -- --skip "convergence_tests::"
+        run: cargo test --workspace --tests -- --skip "convergence_tests::"
       - name: Run tests without convergence tests, release
-        run: cargo test --workspace --all-targets --release -- --skip "convergence_tests::"
+        run: cargo test --workspace --tests --release -- --skip "convergence_tests::"
+      - name: Run benchmarks as tests
+        run: cargo test --workspace --all-targets --benches
 
   cargo-test-convergence:
     
@@ -103,9 +105,5 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.toml') }}
       - uses: dtolnay/rust-toolchain@stable
-      - name: Build all tests (cargo build --tests --workspace --all-targets)
-        run: cargo build --tests --workspace --all-targets
-      - name: Build tests, release (cargo build --tests --workspace --all-targets --release)
-        run: cargo build --tests --workspace --all-targets --release
       - name: Run convergence tests, release
         run: cargo test --workspace --release --test convergence

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,12 +36,8 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-check-${{ hashFiles('**/Cargo.toml') }}
       - uses: dtolnay/rust-toolchain@stable
-      - name: Check
+      - name: Check all targets
         run: cargo check --workspace --all-targets --verbose
-      - name: Check tests
-        run: cargo check --workspace --tests --verbose
-      - name: Check examples
-        run: cargo check --workspace --examples --verbose
 
   cargo-doc:
     

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Run tests without convergence tests, release
         run: cargo test --workspace --tests --release -- --skip "convergence_tests::"
       - name: Run benchmarks as tests
-        run: cargo test --workspace --all-targets --benches
+        run: cargo test --workspace --benches
 
   cargo-test-convergence:
     

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ fenris-optimize = { version= "0.0.3", path = "fenris-optimize" }
 fenris-quadrature = { version= "0.0.4", path = "fenris-quadrature" }
 mshio = "0.4.2"
 rstar = "0.10"
+fxhash = "0.2.1"
 
 [dev-dependencies]
 fenris = { path = ".", features = [ "proptest-support" ]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ rstar = "0.10"
 
 [dev-dependencies]
 fenris = { path = ".", features = [ "proptest-support" ]}
+fenris-solid = { path = "fenris-solid" }
 nalgebra = { workspace = true, features = [ "serde-serialize", "compare" ] }
 proptest = "1.0"
 matrixcompare = { version="0.3", features = ["proptest-support"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ numeric_literals = "0.2.0"
 itertools = "0.10.5"
 ordered-float = "1.0"
 proptest = { version = "1.0", optional = true }
-rayon = "1.3"
+rayon = "1.6.1"
 # TODO: Make serde optional
 serde = { version="1.0", features = [ "derive" ] }
 log = "0.4"
@@ -48,6 +48,7 @@ fenris-quadrature = { version= "0.0.4", path = "fenris-quadrature" }
 mshio = "0.4.2"
 rstar = "0.10"
 fxhash = "0.2.1"
+parking_lot = "0.12.1"
 
 [dev-dependencies]
 fenris = { path = ".", features = [ "proptest-support" ]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ matrixcompare = { version="0.3", features = ["proptest-support"] }
 util = { path = "util" }
 paste = "1.0.6"
 insta = "1.21.0"
+criterion = "0.4.0"
 
 # For outputting e.g. convergence test results for later analysis
 serde_json = "1.0.64"
@@ -86,3 +87,7 @@ repository = "https://github.com/InteractiveComputerGraphics/fenris"
 nalgebra = { version = "0.32.1", default-features = false }
 nalgebra-sparse = { version = "0.9.0", default-features = false }
 fenris = { version = "0.0.24", path = "." }
+
+[[bench]]
+name = "assembly"
+harness = false

--- a/benches/assembly.rs
+++ b/benches/assembly.rs
@@ -1,28 +1,29 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use std::hint::black_box;
-use nalgebra::{DefaultAllocator, DVector, DVectorSlice};
-use nalgebra_sparse::CsrMatrix;
-use nalgebra_sparse::pattern::SparsityPattern;
 use fenris::assembly::global::CsrAssembler;
 use fenris::assembly::local::{ElementEllipticAssemblerBuilder, QuadratureTable};
 use fenris::assembly::operators::LaplaceOperator;
 use fenris::element::ElementConnectivity;
-use fenris::mesh::Mesh;
 use fenris::mesh::procedural::create_unit_box_uniform_tet_mesh_3d;
+use fenris::mesh::Mesh;
 use fenris::quadrature::CanonicalStiffnessQuadrature;
 use fenris::SmallDim;
-use fenris_traits::allocators::{DimAllocator};
+use fenris_traits::allocators::DimAllocator;
+use nalgebra::{DVector, DVectorSlice, DefaultAllocator};
+use nalgebra_sparse::pattern::SparsityPattern;
+use nalgebra_sparse::CsrMatrix;
+use std::hint::black_box;
 
-fn assemble_poisson_into_serial<D, C>(matrix: &mut CsrMatrix<f64>,
-                                      assembler: &CsrAssembler<f64>,
-                                      u: DVectorSlice<f64>,
-                                      qtable: &impl QuadratureTable<f64, D, Data=()>,
-                                      mesh: &Mesh<f64, D, C>)
--> eyre::Result<()>
+fn assemble_poisson_into_serial<D, C>(
+    matrix: &mut CsrMatrix<f64>,
+    assembler: &CsrAssembler<f64>,
+    u: DVectorSlice<f64>,
+    qtable: &impl QuadratureTable<f64, D, Data = ()>,
+    mesh: &Mesh<f64, D, C>,
+) -> eyre::Result<()>
 where
     D: SmallDim,
-    C: ElementConnectivity<f64, GeometryDim=D, ReferenceDim=D>,
-    DefaultAllocator: DimAllocator<f64, D>
+    C: ElementConnectivity<f64, GeometryDim = D, ReferenceDim = D>,
+    DefaultAllocator: DimAllocator<f64, D>,
 {
     let element_assembler = ElementEllipticAssemblerBuilder::new()
         .with_u(u)
@@ -34,15 +35,15 @@ where
 }
 
 fn assemble_poisson_pattern_serial<D, C>(
-                                      assembler: &CsrAssembler<f64>,
-                                      u: DVectorSlice<f64>,
-                                      qtable: &impl QuadratureTable<f64, D, Data=()>,
-                                      mesh: &Mesh<f64, D, C>)
-                                      -> SparsityPattern
-    where
-        D: SmallDim,
-        C: ElementConnectivity<f64, GeometryDim=D, ReferenceDim=D>,
-        DefaultAllocator: DimAllocator<f64, D>
+    assembler: &CsrAssembler<f64>,
+    u: DVectorSlice<f64>,
+    qtable: &impl QuadratureTable<f64, D, Data = ()>,
+    mesh: &Mesh<f64, D, C>,
+) -> SparsityPattern
+where
+    D: SmallDim,
+    C: ElementConnectivity<f64, GeometryDim = D, ReferenceDim = D>,
+    DefaultAllocator: DimAllocator<f64, D>,
 {
     let element_assembler = ElementEllipticAssemblerBuilder::new()
         .with_u(u)
@@ -63,8 +64,14 @@ pub fn poisson_assembly_serial(c: &mut Criterion) {
         let mut matrix = CsrMatrix::try_from_pattern_and_values(pattern, vec![0.0; nnz]).unwrap();
         let u = DVector::repeat(matrix.nrows(), 0.0);
         let qtable = tet4_mesh.canonical_stiffness_quadrature();
-        c.bench_function(&format!("serial assembly poisson stiffness matrix tet4 (res={res})"),
-                         |b| b.iter(|| assemble_poisson_into_serial(&mut matrix, &assembler, DVectorSlice::from(&u), &qtable, &tet4_mesh)));
+        c.bench_function(
+            &format!("serial assembly poisson stiffness matrix tet4 (res={res})"),
+            |b| {
+                b.iter(|| {
+                    assemble_poisson_into_serial(&mut matrix, &assembler, DVectorSlice::from(&u), &qtable, &tet4_mesh)
+                })
+            },
+        );
     }
 }
 
@@ -75,10 +82,25 @@ pub fn poisson_pattern_assembly_serial(c: &mut Criterion) {
         let tet4_mesh = create_unit_box_uniform_tet_mesh_3d(res);
         let u = DVector::repeat(tet4_mesh.vertices().len(), 0.0);
         let qtable = tet4_mesh.canonical_stiffness_quadrature();
-        c.bench_function(&format!("serial pattern assembly poisson stiffness matrix tet4 (res={res})"),
-                         |b| b.iter(|| black_box(assemble_poisson_pattern_serial(&assembler, DVectorSlice::from(&u), &qtable, &tet4_mesh))));
+        c.bench_function(
+            &format!("serial pattern assembly poisson stiffness matrix tet4 (res={res})"),
+            |b| {
+                b.iter(|| {
+                    black_box(assemble_poisson_pattern_serial(
+                        &assembler,
+                        DVectorSlice::from(&u),
+                        &qtable,
+                        &tet4_mesh,
+                    ))
+                })
+            },
+        );
     }
 }
 
-criterion_group!(serial_assembly, poisson_assembly_serial, poisson_pattern_assembly_serial);
+criterion_group!(
+    serial_assembly,
+    poisson_assembly_serial,
+    poisson_pattern_assembly_serial
+);
 criterion_main!(serial_assembly);

--- a/benches/assembly.rs
+++ b/benches/assembly.rs
@@ -1,0 +1,52 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use nalgebra::{DefaultAllocator, DimName, DVector, DVectorSlice};
+use nalgebra_sparse::CsrMatrix;
+use fenris::assembly::global::CsrAssembler;
+use fenris::assembly::local::{ElementEllipticAssemblerBuilder, QuadratureTable, UniformQuadratureTable};
+use fenris::assembly::operators::LaplaceOperator;
+use fenris::element::ElementConnectivity;
+use fenris::mesh::Mesh;
+use fenris::mesh::procedural::create_unit_box_uniform_tet_mesh_3d;
+use fenris::quadrature::CanonicalStiffnessQuadrature;
+use fenris::SmallDim;
+use fenris_traits::allocators::{BiDimAllocator, DimAllocator};
+
+fn assemble_poisson_into_serial<D, C>(matrix: &mut CsrMatrix<f64>,
+                                      assembler: &CsrAssembler<f64>,
+                                      u: DVectorSlice<f64>,
+                                      qtable: &impl QuadratureTable<f64, D, Data=()>,
+                                      mesh: &Mesh<f64, D, C>)
+-> eyre::Result<()>
+where
+    D: SmallDim,
+    C: ElementConnectivity<f64, GeometryDim=D, ReferenceDim=D>,
+    DefaultAllocator: DimAllocator<f64, D>
+{
+    let element_assembler = ElementEllipticAssemblerBuilder::new()
+        .with_u(u)
+        .with_finite_element_space(mesh)
+        .with_operator(&LaplaceOperator)
+        .with_quadrature_table(qtable)
+        .build();
+    assembler.assemble_into_csr(matrix, &element_assembler)
+}
+
+pub fn assembly(c: &mut Criterion) {
+    let resolutions = vec![10, 20];
+    let assembler = CsrAssembler::default();
+    for res in resolutions {
+        let tet4_mesh = create_unit_box_uniform_tet_mesh_3d(res);
+        let pattern = assembler.assemble_pattern(&tet4_mesh);
+        let nnz = pattern.nnz();
+        let mut matrix = CsrMatrix::try_from_pattern_and_values(pattern, vec![0.0; nnz]).unwrap();
+        let mut u = DVector::repeat(matrix.nrows(), 0.0);
+        let qtable = tet4_mesh.canonical_stiffness_quadrature();
+        c.bench_function(&format!("serial assembly poisson stiffness matrix tet4 (res={res})"),
+                         |b| b.iter(|| assemble_poisson_into_serial(&mut matrix, &assembler, DVectorSlice::from(&u), &qtable, &tet4_mesh)));
+    }
+
+
+}
+
+criterion_group!(benches, assembly);
+criterion_main!(benches);

--- a/benches/assembly.rs
+++ b/benches/assembly.rs
@@ -12,6 +12,8 @@ use nalgebra::{DVector, DVectorSlice, DefaultAllocator};
 use nalgebra_sparse::pattern::SparsityPattern;
 use nalgebra_sparse::CsrMatrix;
 use std::hint::black_box;
+use fenris_solid::MaterialEllipticOperator;
+use fenris_solid::materials::{LameParameters, LinearElasticMaterial};
 
 fn assemble_poisson_into_serial<D, C>(
     matrix: &mut CsrMatrix<f64>,
@@ -49,6 +51,28 @@ where
         .with_u(u)
         .with_finite_element_space(mesh)
         .with_operator(&LaplaceOperator)
+        .with_quadrature_table(qtable)
+        .build();
+    assembler.assemble_pattern(&element_assembler)
+}
+
+fn assemble_elasticity_pattern_serial<D, C>(
+    assembler: &CsrAssembler<f64>,
+    u: DVectorSlice<f64>,
+    qtable: &impl QuadratureTable<f64, D, Data = LameParameters<f64>>,
+    mesh: &Mesh<f64, D, C>,
+) -> SparsityPattern
+    where
+        D: SmallDim,
+        C: ElementConnectivity<f64, GeometryDim = D, ReferenceDim = D>,
+        DefaultAllocator: DimAllocator<f64, D>,
+{
+    let material = LinearElasticMaterial;
+    let operator = MaterialEllipticOperator::new(&material);
+    let element_assembler = ElementEllipticAssemblerBuilder::new()
+        .with_u(u)
+        .with_finite_element_space(mesh)
+        .with_operator(&operator)
         .with_quadrature_table(qtable)
         .build();
     assembler.assemble_pattern(&element_assembler)
@@ -98,9 +122,35 @@ pub fn poisson_pattern_assembly_serial(c: &mut Criterion) {
     }
 }
 
+pub fn elasticity_3d_pattern_assembly_serial(c: &mut Criterion) {
+    let resolutions = vec![5, 10, 20];
+    let assembler = CsrAssembler::default();
+    for res in resolutions {
+        let tet4_mesh = create_unit_box_uniform_tet_mesh_3d(res);
+        let u = DVector::repeat(tet4_mesh.vertices().len(), 0.0);
+        let qtable = tet4_mesh.canonical_stiffness_quadrature()
+            .with_uniform_data(LameParameters::default());
+        c.bench_function(
+            &format!("serial pattern assembly elasticity stiffness matrix tet4 (res={res})"),
+            |b| {
+                b.iter(|| {
+                    black_box(assemble_elasticity_pattern_serial(
+                        &assembler,
+                        DVectorSlice::from(&u),
+                        &qtable,
+                        &tet4_mesh,
+                    ))
+                })
+            },
+        );
+    }
+}
+
 criterion_group!(
     serial_assembly,
     poisson_assembly_serial,
-    poisson_pattern_assembly_serial
+    poisson_pattern_assembly_serial,
+    elasticity_3d_pattern_assembly_serial,
 );
+
 criterion_main!(serial_assembly);

--- a/benches/assembly.rs
+++ b/benches/assembly.rs
@@ -1,15 +1,17 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use nalgebra::{DefaultAllocator, DimName, DVector, DVectorSlice};
+use criterion::{criterion_group, criterion_main, Criterion};
+use std::hint::black_box;
+use nalgebra::{DefaultAllocator, DVector, DVectorSlice};
 use nalgebra_sparse::CsrMatrix;
+use nalgebra_sparse::pattern::SparsityPattern;
 use fenris::assembly::global::CsrAssembler;
-use fenris::assembly::local::{ElementEllipticAssemblerBuilder, QuadratureTable, UniformQuadratureTable};
+use fenris::assembly::local::{ElementEllipticAssemblerBuilder, QuadratureTable};
 use fenris::assembly::operators::LaplaceOperator;
 use fenris::element::ElementConnectivity;
 use fenris::mesh::Mesh;
 use fenris::mesh::procedural::create_unit_box_uniform_tet_mesh_3d;
 use fenris::quadrature::CanonicalStiffnessQuadrature;
 use fenris::SmallDim;
-use fenris_traits::allocators::{BiDimAllocator, DimAllocator};
+use fenris_traits::allocators::{DimAllocator};
 
 fn assemble_poisson_into_serial<D, C>(matrix: &mut CsrMatrix<f64>,
                                       assembler: &CsrAssembler<f64>,
@@ -31,22 +33,52 @@ where
     assembler.assemble_into_csr(matrix, &element_assembler)
 }
 
-pub fn assembly(c: &mut Criterion) {
-    let resolutions = vec![10, 20];
+fn assemble_poisson_pattern_serial<D, C>(
+                                      assembler: &CsrAssembler<f64>,
+                                      u: DVectorSlice<f64>,
+                                      qtable: &impl QuadratureTable<f64, D, Data=()>,
+                                      mesh: &Mesh<f64, D, C>)
+                                      -> SparsityPattern
+    where
+        D: SmallDim,
+        C: ElementConnectivity<f64, GeometryDim=D, ReferenceDim=D>,
+        DefaultAllocator: DimAllocator<f64, D>
+{
+    let element_assembler = ElementEllipticAssemblerBuilder::new()
+        .with_u(u)
+        .with_finite_element_space(mesh)
+        .with_operator(&LaplaceOperator)
+        .with_quadrature_table(qtable)
+        .build();
+    assembler.assemble_pattern(&element_assembler)
+}
+
+pub fn poisson_assembly_serial(c: &mut Criterion) {
+    let resolutions = vec![5, 10, 20];
     let assembler = CsrAssembler::default();
     for res in resolutions {
         let tet4_mesh = create_unit_box_uniform_tet_mesh_3d(res);
         let pattern = assembler.assemble_pattern(&tet4_mesh);
         let nnz = pattern.nnz();
         let mut matrix = CsrMatrix::try_from_pattern_and_values(pattern, vec![0.0; nnz]).unwrap();
-        let mut u = DVector::repeat(matrix.nrows(), 0.0);
+        let u = DVector::repeat(matrix.nrows(), 0.0);
         let qtable = tet4_mesh.canonical_stiffness_quadrature();
         c.bench_function(&format!("serial assembly poisson stiffness matrix tet4 (res={res})"),
                          |b| b.iter(|| assemble_poisson_into_serial(&mut matrix, &assembler, DVectorSlice::from(&u), &qtable, &tet4_mesh)));
     }
-
-
 }
 
-criterion_group!(benches, assembly);
-criterion_main!(benches);
+pub fn poisson_pattern_assembly_serial(c: &mut Criterion) {
+    let resolutions = vec![5, 10, 20];
+    let assembler = CsrAssembler::default();
+    for res in resolutions {
+        let tet4_mesh = create_unit_box_uniform_tet_mesh_3d(res);
+        let u = DVector::repeat(tet4_mesh.vertices().len(), 0.0);
+        let qtable = tet4_mesh.canonical_stiffness_quadrature();
+        c.bench_function(&format!("serial pattern assembly poisson stiffness matrix tet4 (res={res})"),
+                         |b| b.iter(|| black_box(assemble_poisson_pattern_serial(&assembler, DVectorSlice::from(&u), &qtable, &tet4_mesh))));
+    }
+}
+
+criterion_group!(serial_assembly, poisson_assembly_serial, poisson_pattern_assembly_serial);
+criterion_main!(serial_assembly);

--- a/benches/assembly.rs
+++ b/benches/assembly.rs
@@ -11,7 +11,7 @@ use fenris_solid::materials::{LameParameters, LinearElasticMaterial};
 use fenris_solid::MaterialEllipticOperator;
 use fenris_traits::allocators::DimAllocator;
 use nalgebra::allocator::Allocator;
-use nalgebra::{DVector, DVectorSlice, DefaultAllocator};
+use nalgebra::{DVector, DVectorView, DefaultAllocator};
 use nalgebra_sparse::pattern::SparsityPattern;
 use nalgebra_sparse::CsrMatrix;
 use std::hint::black_box;
@@ -19,7 +19,7 @@ use std::hint::black_box;
 fn assemble_poisson_into_serial<D, C>(
     matrix: &mut CsrMatrix<f64>,
     assembler: &CsrAssembler<f64>,
-    u: DVectorSlice<f64>,
+    u: DVectorView<f64>,
     qtable: &impl QuadratureTable<f64, D, Data = ()>,
     mesh: &Mesh<f64, D, C>,
 ) -> eyre::Result<()>
@@ -39,7 +39,7 @@ where
 
 fn assemble_poisson_pattern_serial<D, C>(
     assembler: &CsrAssembler<f64>,
-    u: DVectorSlice<f64>,
+    u: DVectorView<f64>,
     qtable: &impl QuadratureTable<f64, D, Data = ()>,
     mesh: &Mesh<f64, D, C>,
 ) -> SparsityPattern
@@ -59,7 +59,7 @@ where
 
 fn assemble_poisson_pattern_par<D, C>(
     assembler: &CsrParAssembler<f64>,
-    u: DVectorSlice<f64>,
+    u: DVectorView<f64>,
     qtable: &(impl QuadratureTable<f64, D, Data = ()> + Sync),
     mesh: &Mesh<f64, D, C>,
 ) -> SparsityPattern
@@ -80,7 +80,7 @@ where
 
 fn assemble_elasticity_pattern_serial<D, C>(
     assembler: &CsrAssembler<f64>,
-    u: DVectorSlice<f64>,
+    u: DVectorView<f64>,
     qtable: &impl QuadratureTable<f64, D, Data = LameParameters<f64>>,
     mesh: &Mesh<f64, D, C>,
 ) -> SparsityPattern
@@ -102,7 +102,7 @@ where
 
 fn assemble_elasticity_pattern_par<D, C>(
     assembler: &CsrParAssembler<f64>,
-    u: DVectorSlice<f64>,
+    u: DVectorView<f64>,
     qtable: &(impl QuadratureTable<f64, D, Data = LameParameters<f64>> + Sync),
     mesh: &Mesh<f64, D, C>,
 ) -> SparsityPattern
@@ -137,7 +137,7 @@ pub fn poisson_assembly_serial(c: &mut Criterion) {
             &format!("serial assembly poisson stiffness matrix tet4 (res={res})"),
             |b| {
                 b.iter(|| {
-                    assemble_poisson_into_serial(&mut matrix, &assembler, DVectorSlice::from(&u), &qtable, &tet4_mesh)
+                    assemble_poisson_into_serial(&mut matrix, &assembler, DVectorView::from(&u), &qtable, &tet4_mesh)
                 })
             },
         );
@@ -157,7 +157,7 @@ pub fn poisson_pattern_assembly_serial(c: &mut Criterion) {
                 b.iter(|| {
                     black_box(assemble_poisson_pattern_serial(
                         &assembler,
-                        DVectorSlice::from(&u),
+                        DVectorView::from(&u),
                         &qtable,
                         &tet4_mesh,
                     ))
@@ -180,7 +180,7 @@ pub fn poisson_pattern_assembly_parallel(c: &mut Criterion) {
                 b.iter(|| {
                     black_box(assemble_poisson_pattern_par(
                         &assembler,
-                        DVectorSlice::from(&u),
+                        DVectorView::from(&u),
                         &qtable,
                         &tet4_mesh,
                     ))
@@ -205,7 +205,7 @@ pub fn elasticity_3d_pattern_assembly_serial(c: &mut Criterion) {
                 b.iter(|| {
                     black_box(assemble_elasticity_pattern_serial(
                         &assembler,
-                        DVectorSlice::from(&u),
+                        DVectorView::from(&u),
                         &qtable,
                         &tet4_mesh,
                     ))
@@ -230,7 +230,7 @@ pub fn elasticity_3d_pattern_assembly_parallel(c: &mut Criterion) {
                 b.iter(|| {
                     black_box(assemble_elasticity_pattern_par(
                         &assembler,
-                        DVectorSlice::from(&u),
+                        DVectorView::from(&u),
                         &qtable,
                         &tet4_mesh,
                     ))

--- a/src/assembly/global.rs
+++ b/src/assembly/global.rs
@@ -6,16 +6,20 @@ use crate::Real;
 use fenris_nested_vec::NestedVec;
 use fenris_paradis::adapter::BlockAdapter;
 use fenris_paradis::coloring::sequential_greedy_coloring;
-use fenris_paradis::DisjointSubsets;
+use fenris_paradis::{DisjointSubsets, ParallelIndexedCollection};
 use fenris_sparse::ParallelCsrRowCollection;
+use itertools::{enumerate, izip};
 use nalgebra::base::storage::Storage;
 use nalgebra::{DMatrix, DMatrixViewMut, DVector, DVectorView, DVectorViewMut, DimName, Dyn, Matrix, Scalar, U1};
 use nalgebra_sparse::{pattern::SparsityPattern, CsrMatrix};
+use num::integer::div_ceil;
+use parking_lot::Mutex;
 use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
 use rayon::slice::ParallelSliceMut;
-use std::cell::RefCell;
-use std::ops::AddAssign;
 use rustc_hash::FxHashSet;
+use std::cell::RefCell;
+use std::cmp::min;
+use std::ops::{AddAssign, IndexMut};
 use thread_local::ThreadLocal;
 
 /// An assembler for CSR matrices.
@@ -54,7 +58,10 @@ impl<T: Scalar> Default for CsrAssemblerWorkspace<T> {
 }
 
 impl<T: Scalar> CsrAssembler<T> {
-    // TODO: Test this method!
+    /// Assembles the sparsity pattern associated with the given element assembler.
+    ///
+    /// The implementation explicitly avoids storing duplicate entries in order to prevent
+    /// excessive memory costs.
     pub fn assemble_pattern(&self, element_assembler: &impl ElementConnectivityAssembler) -> SparsityPattern {
         let sdim = element_assembler.solution_dim();
         let num_nodes = element_assembler.num_nodes();
@@ -77,7 +84,7 @@ impl<T: Scalar> CsrAssembler<T> {
         offsets.push(0);
         let mut current_offset = 0;
         for node_set in &node_sets {
-            for _ in 0 .. sdim {
+            for _ in 0..sdim {
                 let count = sdim * node_set.len();
                 offsets.push(current_offset + count);
                 current_offset += count;
@@ -92,21 +99,24 @@ impl<T: Scalar> CsrAssembler<T> {
             node_buffer.extend(node_set);
             node_buffer.sort_unstable();
             // We have sdim identical rows (in terms of pattern)
-            for _ in 0 .. sdim {
+            for _ in 0..sdim {
                 for node_j in &node_buffer {
-                        for j in 0 .. sdim {
-                            let col_idx = sdim * node_j + j;
-                            col_indices.push(col_idx);
-                        }
+                    for j in 0..sdim {
+                        let col_idx = sdim * node_j + j;
+                        col_indices.push(col_idx);
+                    }
                 }
             }
         }
 
         assert_eq!(*offsets.last().unwrap(), col_indices.len());
 
-        // TODO: Avoid validation?
-        SparsityPattern::try_from_offsets_and_indices(num_rows, num_rows, offsets, col_indices)
-            .expect("Pattern data must be valid")
+        debug_assert!(
+            SparsityPattern::try_from_offsets_and_indices(num_rows, num_rows, offsets.clone(), col_indices.clone())
+                .is_ok(),
+            "Internal error: constructed sparsity pattern is not valid. This is a bug!"
+        );
+        unsafe { SparsityPattern::from_offset_and_indices_unchecked(num_rows, num_rows, offsets, col_indices) }
     }
 }
 
@@ -189,80 +199,101 @@ impl<T: Scalar + Send> Default for CsrParAssembler<T> {
 }
 
 impl<T: Scalar + Send> CsrParAssembler<T> {
+    /// Assembles the sparsity pattern associated with the given element assembler.
+    ///
+    /// The implementation explicitly avoids storing duplicate entries in order to prevent
+    /// excessive memory costs.
     pub fn assemble_pattern(&self, element_assembler: &(impl Sync + ElementConnectivityAssembler)) -> SparsityPattern {
         let sdim = element_assembler.solution_dim();
+        let num_nodes = element_assembler.num_nodes();
+        let num_elements = element_assembler.num_elements();
+        let num_rows = sdim * num_nodes;
+        // We store a HashSet (with a fast hash) for each node,
+        // eventually containing the set of (unique) neighbors for that node
+        let mut node_sets: Vec<Mutex<FxHashSet<usize>>> = (0..num_nodes)
+            .map(|_| Mutex::new(FxHashSet::default()))
+            .collect();
+        let node_buffer: ThreadLocal<RefCell<Vec<usize>>> = ThreadLocal::new();
 
-        // Count number of (including duplicate) triplets
-        let num_total_triplets = (0..element_assembler.num_elements())
-            .into_par_iter()
-            .with_min_len(50)
-            .map(|element_idx| {
-                let num_entries = sdim * element_assembler.element_node_count(element_idx);
-                num_entries * num_entries
-            })
-            .sum();
+        // Batch computation in order to make each Rayon unit of work larger
+        let batch_size = 10;
+        let num_batches = div_ceil(num_elements, batch_size);
+        (0..num_batches).into_par_iter().for_each(|batch_index| {
+            let batch_start = batch_size * batch_index;
+            let batch_end = min(num_elements, batch_start + batch_size);
+            assert!(batch_end >= batch_start);
+            let mut node_buffer = node_buffer.get_or_default().borrow_mut();
+            for i in batch_start..batch_end {
+                let element_node_count = element_assembler.element_node_count(i);
+                node_buffer.resize(element_node_count, usize::MAX);
+                element_assembler.populate_element_nodes(&mut node_buffer, i);
 
-        // TODO: Can we do this next stage in parallel somehow?
-        // (it is however entirely memory bound, but a single thread
-        // probably cannot exhaust that on its own)
-        let mut coordinates = Vec::with_capacity(num_total_triplets);
-        let mut index_workspace = Vec::new();
-        for element_idx in 0..element_assembler.num_elements() {
-            let node_count = element_assembler.element_node_count(element_idx);
-            index_workspace.resize(node_count, 0);
-            element_assembler.populate_element_nodes(&mut index_workspace, element_idx);
-
-            for node_i in &index_workspace {
-                for node_j in &index_workspace {
-                    for i in 0..sdim {
-                        for j in 0..sdim {
-                            coordinates.push((sdim * node_i + i, sdim * node_j + j));
-                        }
+                for &node_i in &*node_buffer {
+                    let mut node_set = node_sets[node_i].lock();
+                    for &node_j in &*node_buffer {
+                        node_set.insert(node_j);
                     }
                 }
             }
-        }
+        });
 
-        coordinates.par_sort_unstable();
-
-        // TODO: Can we parallelize the final part?
-        // TODO: move this into something like SparsityPattern::from_coordinates ?
-        // But then we'd probably also have to deal with the case in which
-        // the coordinates are perhaps not sorted (either error out or
-        // deal with it on the fly)
-        let num_rows = sdim * element_assembler.num_nodes();
-        let mut row_offsets = Vec::with_capacity(num_rows);
-        let mut column_indices = Vec::new();
-        row_offsets.push(0);
-
-        let mut coord_iter = coordinates.into_iter();
-        let mut current_row = 0;
-        let mut prev_col = None;
-
-        while let Some((i, j)) = coord_iter.next() {
-            assert!(i < num_rows, "Coordinates must be in bounds");
-
-            while i > current_row {
-                row_offsets.push(column_indices.len());
-                current_row += 1;
-                prev_col = None;
-            }
-
-            // Only add column if it is not a duplicate
-            if Some(j) != prev_col {
-                column_indices.push(j);
-                prev_col = Some(j);
+        // TODO: Parallelize offset computation
+        // (only takes up relatively small proportion of time though, not worth spending much effort atm)
+        let mut offsets = Vec::with_capacity(num_rows);
+        offsets.push(0);
+        let mut current_offset = 0;
+        for node_set in &node_sets {
+            for _ in 0..sdim {
+                let count = sdim * node_set.lock().len();
+                offsets.push(current_offset + count);
+                current_offset += count;
             }
         }
 
-        // Fill out offsets for remaining empty rows
-        for _ in current_row..num_rows {
-            row_offsets.push(column_indices.len());
-        }
+        let nnz = current_offset;
+        assert_eq!(offsets.len(), num_rows + 1);
 
-        // TODO: Avoid validation?
-        SparsityPattern::try_from_offsets_and_indices(num_rows, num_rows, row_offsets, column_indices)
-            .expect("Pattern data must be valid by definition")
+        let mut col_indices = vec![0; nnz];
+        let col_indices_access = unsafe { col_indices.create_access() };
+
+        // Note: We use the same batch size, but before we were batching over *elements*,
+        // now we're batching over *rows*
+        node_sets
+            .par_chunks_mut(batch_size)
+            .enumerate()
+            .for_each(|(batch_index, locked_node_sets)| {
+                let batch_start = batch_size * batch_index;
+                let batch_end = min(num_nodes, batch_start + batch_size);
+                assert!(batch_end >= batch_start);
+                let mut node_buffer = node_buffer.get_or_default().borrow_mut();
+
+                for (i, locked_node_set) in izip!(batch_start..batch_end, locked_node_sets) {
+                    let node_set = locked_node_set.get_mut();
+                    node_buffer.clear();
+                    node_buffer.extend(node_set.iter());
+                    node_buffer.sort_unstable();
+
+                    for s_i in 0..sdim {
+                        let begin = offsets[sdim * i + s_i];
+                        let end = offsets[sdim * i + s_i + 1];
+                        let subslice = unsafe { col_indices_access.subslice_mut(begin..end) };
+                        for (i, node_j) in enumerate(node_buffer.iter()) {
+                            let block = subslice.index_mut(sdim * i..(sdim * (i + 1)));
+                            for (j, col_idx) in enumerate(block) {
+                                *col_idx = sdim * node_j + j;
+                            }
+                        }
+                    }
+                }
+            });
+
+        assert_eq!(*offsets.last().unwrap(), col_indices.len());
+        debug_assert!(
+            SparsityPattern::try_from_offsets_and_indices(num_rows, num_rows, offsets.clone(), col_indices.clone())
+                .is_ok(),
+            "Internal error: constructed sparsity pattern is not valid. This is a bug!"
+        );
+        unsafe { SparsityPattern::from_offset_and_indices_unchecked(num_rows, num_rows, offsets, col_indices) }
     }
 }
 

--- a/src/assembly/global.rs
+++ b/src/assembly/global.rs
@@ -14,8 +14,8 @@ use nalgebra_sparse::{pattern::SparsityPattern, CsrMatrix};
 use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
 use rayon::slice::ParallelSliceMut;
 use std::cell::RefCell;
-use fxhash::FxHashSet as HashSet;
 use std::ops::AddAssign;
+use rustc_hash::FxHashSet;
 use thread_local::ThreadLocal;
 
 /// An assembler for CSR matrices.
@@ -59,7 +59,7 @@ impl<T: Scalar> CsrAssembler<T> {
         let sdim = element_assembler.solution_dim();
         let num_nodes = element_assembler.num_nodes();
         let num_rows = sdim * num_nodes;
-        let mut node_sets: Vec<HashSet<usize>> = vec![HashSet::default(); num_nodes];
+        let mut node_sets: Vec<FxHashSet<usize>> = vec![FxHashSet::default(); num_nodes];
         let mut element_global_nodes = Vec::new();
         for i in 0..element_assembler.num_elements() {
             let element_node_count = element_assembler.element_node_count(i);

--- a/tests/unit_tests/assembly/global.rs
+++ b/tests/unit_tests/assembly/global.rs
@@ -123,7 +123,7 @@ fn csr_assemble_mock_pattern() {
             num_nodes: 6,
             element_connectivities: vec![vec![0, 1, 2], vec![2, 3], vec![], vec![3, 4, 4, 4, 4, 4, 4]],
         };
-        let csr_assembler = CsrParAssembler::<i32>::default();
+        let csr_assembler = CsrAssembler::<i32>::default();
         let pattern = csr_assembler.assemble_pattern(&element_assembler);
         let expected_pattern = SparsityPattern::try_from_offsets_and_indices(
             12,


### PR DESCRIPTION
Massively improves performance of sparsity pattern assembly, both single threaded and parallel.

Unfortunately there seems to be some unclear issues with `rayon` that makes the parallel version quite a bit slower when running on a single thread compared to the explicitly single threaded version. Should make an issue for this after merging.

