### PR TITLE
Allow implementing hyperelastic materials that depend on displacement gradient

### DIFF
--- a/fenris-solid/src/logdet.rs
+++ b/fenris-solid/src/logdet.rs
@@ -1,0 +1,86 @@
+use crate::PhysicalDim;
+use fenris::allocators::DimAllocator;
+use fenris::nalgebra::{DefaultAllocator, Matrix1, Matrix2, Matrix3, OMatrix};
+use fenris::util::try_transmute_ref;
+use fenris::Real;
+use numeric_literals::replace_float_literals;
+
+/// Compute $\log(\det \vec F)$ for the deformation gradient $\vec F$ given $\pd{\vec u}{\vec X}$.
+///
+/// The implementation may be far more accurate than first forming $\vec F$, which discards
+/// valuable information for small deformations (small $\pd{\vec u}{\vec X}$).
+///
+/// The implementation is based on the technique described in the
+/// [libCEED documentation](https://libceed.org/en/latest/examples/solids).
+#[allow(non_snake_case)]
+#[replace_float_literals(T::from_f64(literal).unwrap())]
+pub fn log_det_F<T, D>(du_dX: &OMatrix<T, D, D>) -> Option<T>
+where
+    T: Real,
+    D: PhysicalDim,
+    DefaultAllocator: DimAllocator<T, D>,
+{
+    match D::USIZE {
+        1 => {
+            let du_dX: &Matrix1<T> = try_transmute_ref(du_dX).unwrap();
+            let det = du_dX[(0, 0)];
+            (det > 0.0).then(|| det.ln())
+        }
+        2 => log_det_F_2d(try_transmute_ref(du_dX).unwrap()),
+        3 => log_det_F_3d(try_transmute_ref(du_dX).unwrap()),
+        _ => unreachable!("Physical dimensions do not extend past 3 dimensions"),
+    }
+}
+
+#[allow(non_snake_case)]
+#[replace_float_literals(T::from_f64(literal).unwrap())]
+fn log_det_F_2d<T: Real>(du_dX: &Matrix2<T>) -> Option<T> {
+    // See comments in 3D impl for more elaborate explanation
+    // Given a matrix A = [a, b; c, d] the determinant is
+    //  det(A) = ad - bc
+    // Let U = du_dX be the displacement Jacobian and uij its entries. Then we can write our determinant as
+    //   det(F) = det(I + U) = a*d - b*c = (1+u11)*(1+u22) - b*c
+    //          = 1 + u11*u22 + u11 + u22 - b*c
+    //          = 1 + γ
+    // and so
+    //   log(det(F)) = log(1 + γ) = log1p(γ)
+    let u11 = du_dX[(0, 0)];
+    let u22 = du_dX[(1, 1)];
+    let b = du_dX[(0, 1)];
+    let c = du_dX[(1, 0)];
+    let gamma = u11 * u22 + u11 + u22 - b * c;
+    (gamma > -1.0).then(|| T::ln_1p(gamma))
+}
+
+#[allow(non_snake_case)]
+#[replace_float_literals(T::from_f64(literal).unwrap())]
+fn log_det_F_3d<T: Real>(du_dX: &Matrix3<T>) -> Option<T> {
+    // Given a matrix A = [a, b, c; d, e, f; g, h, i] the determinant is
+    //  det(A) = aei + bfg + cdh - ceg - bdi - afh
+    // The first term is the product of the diagonals. Since F = I + du_dX,
+    // the diagonal of F will be close to 1 for small du_dX,
+    // and so the determinant is dominated by this first term.
+    // Let U = du_dX be the displacement Jacobian and uij its entries. Then we can write our determinant as
+    //   det(F) = det(I + U) = (1+u11)*(1+u22)*(1+u33) + ...
+    //          = 1 + u11*u22*u33 + u11*u22 + u11*u33 + u22*u33 + u11 + u22 + u33 + ...
+    //          = 1 + γ
+    // and so
+    //   log(det(F)) = log(1 + γ) = log1p(γ)
+    let u11 = du_dX[(0, 0)];
+    let u22 = du_dX[(1, 1)];
+    let u33 = du_dX[(2, 2)];
+    let a = 1.0 + u11;
+    let e = 1.0 + u22;
+    let i = 1.0 + u33;
+    let b = du_dX[(0, 1)];
+    let c = du_dX[(0, 2)];
+    let d = du_dX[(1, 0)];
+    let f = du_dX[(1, 2)];
+    let g = du_dX[(2, 0)];
+    let h = du_dX[(2, 1)];
+    let gamma = u11 * u22 * u33 + u11 * u22 + u11 * u33 + u22 * u33 + u11 + u22 + u33 + b * f * g + c * d * h
+        - c * e * g
+        - b * d * i
+        - a * f * h;
+    (gamma > -1.0).then(|| T::ln_1p(gamma))
+}

--- a/fenris-solid/tests/unit_tests/logdet.rs
+++ b/fenris-solid/tests/unit_tests/logdet.rs
@@ -1,0 +1,50 @@
+use fenris::nalgebra;
+use fenris::nalgebra::{matrix, vector, Matrix3, Rotation3};
+use fenris_solid::{log_det_F, u_grad_from_F};
+use matrixcompare::assert_scalar_eq;
+
+#[allow(non_snake_case)]
+fn arbitrary_F() -> Matrix3<f64> {
+    // We construct F by an ad-hoc SVD construction. This way we can control the singular values
+    // and determinant (since rotations have determinant 1)
+    let rot1 = Rotation3::from_scaled_axis(vector![1.0, 2.0, -3.0])
+        .matrix()
+        .clone_owned();
+    let rot2 = Rotation3::from_scaled_axis(vector![4.0, -5.0, 6.0])
+        .matrix()
+        .clone_owned();
+    let sigma = matrix![1.0 + 0.1, 0.0, 0.0;
+                            0.0, 1.0 - 0.2, 0.0;
+                            0.0, 0.0, 1.0 + 0.3];
+    rot1 * sigma * rot2
+}
+
+#[test]
+#[allow(non_snake_case)]
+fn test_log_det_F() {
+    let F = arbitrary_F();
+    let du_dX = F - Matrix3::identity();
+    assert_scalar_eq!(
+        log_det_F(&du_dX).unwrap(),
+        F.determinant().ln(),
+        comp = abs,
+        tol = 1e-12
+    );
+}
+
+#[test]
+#[allow(non_snake_case)]
+fn log_det_negative_determinant() {
+    let rot1 = Rotation3::from_scaled_axis(vector![1.0, 2.0, -3.0])
+        .matrix()
+        .clone_owned();
+    let rot2 = Rotation3::from_scaled_axis(vector![4.0, -5.0, 6.0])
+        .matrix()
+        .clone_owned();
+    let sigma = matrix![-1e-6, 0.0, 0.0;
+                            0.0, 1.0, 0.0;
+                            0.0, 0.0, 1.0 + 0.3];
+    let F = rot1 * sigma * rot2;
+    let du_dX = u_grad_from_F(&F).transpose();
+    assert!(log_det_F(&du_dX).is_none());
+}

--- a/fenris-solid/tests/unit_tests/mod.rs
+++ b/fenris-solid/tests/unit_tests/mod.rs
@@ -4,6 +4,7 @@ use fenris::nalgebra::{matrix, Matrix2, Matrix3, Point3};
 use fenris_solid::materials::LameParameters;
 
 mod gravity_source;
+mod logdet;
 mod material_elliptic_operator;
 mod materials;
 

--- a/src/assembly/local/elliptic.rs
+++ b/src/assembly/local/elliptic.rs
@@ -522,8 +522,8 @@ where
 
         let mut output =
             MatrixViewMut::from_slice_generic(output.as_mut_slice(), Operator::SolutionDim::name(), Dyn(n));
-        let g = operator.compute_elliptic_operator(&u_grad, data);
-        let g_t_j_inv_t = g.transpose() * j_inv_t;
+        let g_t = operator.compute_elliptic_operator_transpose(&u_grad, data);
+        let g_t_j_inv_t = g_t * j_inv_t;
         output.gemm(weight * j_det.abs(), &g_t_j_inv_t, &phi_grad_ref, T::one());
     }
 

--- a/src/assembly/operators.rs
+++ b/src/assembly/operators.rs
@@ -1,5 +1,4 @@
 use crate::allocators::BiDimAllocator;
-use crate::nalgebra::allocator::Allocator;
 use crate::nalgebra::{DMatrixViewMut, DVectorView, DefaultAllocator, DimName, OMatrix, OVector, Scalar};
 use crate::{Real, SmallDim, Symmetry};
 
@@ -22,7 +21,7 @@ pub trait EllipticOperator<T, GeometryDim>: Operator<T, GeometryDim>
 where
     T: Scalar,
     GeometryDim: SmallDim,
-    DefaultAllocator: Allocator<T, GeometryDim, Self::SolutionDim>,
+    DefaultAllocator: BiDimAllocator<T, GeometryDim, Self::SolutionDim>,
 {
     /// Compute the elliptic operator $g = g(\nabla u)$ with the provided
     /// [operator parameters](Operator::Parameters).
@@ -31,6 +30,19 @@ where
         gradient: &OMatrix<T, GeometryDim, Self::SolutionDim>,
         parameters: &Self::Parameters,
     ) -> OMatrix<T, GeometryDim, Self::SolutionDim>;
+
+    /// Compute the transpose $g^T$ of the elliptic operator $g$.
+    ///
+    /// See [`compute_elliptic_operator`](Self::compute_elliptic_operator). Implementing
+    /// this function can often avoid unnecessary transposition in consumers.
+    fn compute_elliptic_operator_transpose(
+        &self,
+        gradient: &OMatrix<T, GeometryDim, Self::SolutionDim>,
+        parameters: &Self::Parameters,
+    ) -> OMatrix<T, Self::SolutionDim, GeometryDim> {
+        self.compute_elliptic_operator(gradient, parameters)
+            .transpose()
+    }
 }
 
 /// A contraction operator encoding derivative information for an elliptic operator.


### PR DESCRIPTION
By depending on $\nabla u$ instead of the deformation gradient $F$, we can avoid the loss of accuracy in forming $F$, which causes a severe loss of accuracy for very stiff materials subject to small displacements.

This is a preliminary stopgap design. Longer term we might consider making the entire hyperelastic material trait depend on $\nabla u$ instead of $F$, and rewriting all materials to use more numerically stable implementations.